### PR TITLE
Add files via upload

### DIFF
--- a/default_game_configs/spyro_reignited_trilogy.yaml
+++ b/default_game_configs/spyro_reignited_trilogy.yaml
@@ -1,0 +1,6 @@
+name: Spyro™ Reignited Trilogy
+steamappid: 996580
+
+nexus_game_id: spyroreignitedtrilogy
+
+mods_path: Falcon/Content/Paks/~mods/


### PR DESCRIPTION
First working Spyro™ Reignited Trilogy extension on Steam.

So far I've only used mods that target 1 mod folder destination mods_path: Falcon/Content/Paks/~mods/

I'm unaware if there are mods that use other paths.