### PR TITLE
New YAMLs

### DIFF
--- a/default_game_configs/final_fantasy_7_rebirth.yaml
+++ b/default_game_configs/final_fantasy_7_rebirth.yaml
@@ -1,0 +1,12 @@
+name: FINAL FANTASY VII REBIRTH
+steamappid: 2909400
+
+nexus_game_id: finalfantasy7rebirth
+
+mods_path:
+- path: End/Content/Paks/~mods/
+  name: Default
+  description: Regular mods that go in the ~mods folder
+- path: End/Mods/
+  name: Dresscode Mods
+  description: Mods specifically made for Dresscode

--- a/default_game_configs/final_fantasy_7_remake.yaml
+++ b/default_game_configs/final_fantasy_7_remake.yaml
@@ -1,0 +1,6 @@
+name: FINAL FANTASY VII REMAKE
+steamappid: 1462040
+
+nexus_game_id: finalfantasy7remake
+
+mods_path: End/Content/Paks/~mods/

--- a/default_game_configs/metal_gear_solid_delta.yaml
+++ b/default_game_configs/metal_gear_solid_delta.yaml
@@ -1,0 +1,6 @@
+name: MGSDelta
+steamappid: 2417610
+
+nexus_game_id: metalgearsoliddeltasnakeeater
+
+mods_path: MGSDelta/Content/Paks/~mods/

--- a/default_game_configs/spyro_reignited_trilogy.yaml
+++ b/default_game_configs/spyro_reignited_trilogy.yaml
@@ -1,0 +1,6 @@
+name: Spyro™ Reignited Trilogy
+steamappid: 996580
+
+nexus_game_id: spyroreignitedtrilogy
+
+mods_path: Falcon/Content/Paks/~mods/

--- a/default_game_configs/spyro_reignited_trilogy.yaml
+++ b/default_game_configs/spyro_reignited_trilogy.yaml
@@ -1,6 +1,0 @@
-name: Spyro™ Reignited Trilogy
-steamappid: 996580
-
-nexus_game_id: spyroreignitedtrilogy
-
-mods_path: Falcon/Content/Paks/~mods/

--- a/default_game_configs/spyro_reignited_trilogy.yaml
+++ b/default_game_configs/spyro_reignited_trilogy.yaml
@@ -1,0 +1,6 @@
+name: Spyro Reignited Trilogy
+steamappid: 996580
+
+nexus_game_id: spyroreignitedtrilogy
+
+mods_path: Falcon/Content/Paks/~mods/


### PR DESCRIPTION
Added and tested STEAM VERSIONS of

Spyro
Metal Gear Solid Delta
Final Fantasy VII Remake
Final Fantasy VII Rebirth

Final Fantasy VII Rebirth instructions

For Dresscode mods you need Reunion Mod Loader and Game Instance Loader.

Both Reunion Mod Loader and Game Instance Loader are on the same page. 
However additional steps (explained on the same page) are needed if using FFVIIHook which I'm not.

For how to download these effortlessly: 

Reunion Mod Loader has to be installed as Dresscode Mods
Game Instance Loader has to be installed as Default Mods
Dresscode - Costume Changer has to be installed as Dresscode Mods

Reunion Mod Loader is only needed for Dresscode mods alone.
If someone isn't using any Dresscode mods, they can simply install mods as default.



Reunion Mod Loader and Game Instance Loader
https://www.nexusmods.com/finalfantasy7rebirth/mods/1061?tab=files

Dresscode - Costume Changer
https://www.nexusmods.com/finalfantasy7rebirth/mods/1062?tab=description