### PR TITLE
Added 3 more titles

### DIFF
--- a/default_game_configs/kingdom_hearts_3.yaml
+++ b/default_game_configs/kingdom_hearts_3.yaml
@@ -1,6 +1,0 @@
-name: KINGDOM HEARTS III
-steamappid: 2552450
-
-nexus_game_id: kingdomhearts3
-
-mods_path: KINGDOM HEARTS III/Content/Paks/~mods/

--- a/default_game_configs/kingdom_hearts_3.yaml
+++ b/default_game_configs/kingdom_hearts_3.yaml
@@ -1,0 +1,6 @@
+name: "KINGDOM HEARTS III"
+steam_folder_name: KINGDOM HEARTS III
+steam_id: 2552450
+nexus_id: kingdomhearts3
+
+mods_path: KINGDOM HEARTS III/Content/Paks/~mods/

--- a/default_game_configs/kingdom_hearts_3.yaml
+++ b/default_game_configs/kingdom_hearts_3.yaml
@@ -1,0 +1,6 @@
+name: KINGDOM HEARTS III
+steamappid: 2552450
+
+nexus_game_id: kingdomhearts3
+
+mods_path: KINGDOM HEARTS III/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_fallen_order.yaml
+++ b/default_game_configs/star_wars_jedi_fallen_order.yaml
@@ -1,0 +1,6 @@
+name: Jedi Fallen Order
+steamappid: 1172380
+
+nexus_game_id: starwarsjedifallenorder
+
+mods_path: SwGame/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_fallen_order.yaml
+++ b/default_game_configs/star_wars_jedi_fallen_order.yaml
@@ -1,0 +1,6 @@
+name: "STAR WARS Jedi Fallen Order"
+steam_folder_name: Jedi Fallen Order
+steam_id: 1172380
+nexus_id: starwarsjedifallenorder
+
+mods_path: SwGame/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_fallen_order.yaml
+++ b/default_game_configs/star_wars_jedi_fallen_order.yaml
@@ -1,6 +1,0 @@
-name: Jedi Fallen Order
-steamappid: 1172380
-
-nexus_game_id: starwarsjedifallenorder
-
-mods_path: SwGame/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_survivor.yaml
+++ b/default_game_configs/star_wars_jedi_survivor.yaml
@@ -1,6 +1,0 @@
-name: Jedi Survivor
-steamappid: 1774580
-
-nexus_game_id: starwarsjedisurvivor
-
-mods_path: SwGame/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_survivor.yaml
+++ b/default_game_configs/star_wars_jedi_survivor.yaml
@@ -1,0 +1,6 @@
+name: "STAR WARS Jedi Survivor"
+steam_folder_name: Jedi Survivor
+steam_id: 1774580
+nexus_id: starwarsjedisurvivor
+
+mods_path: SwGame/Content/Paks/~mods/

--- a/default_game_configs/star_wars_jedi_survivor.yaml
+++ b/default_game_configs/star_wars_jedi_survivor.yaml
@@ -1,0 +1,6 @@
+name: Jedi Survivor
+steamappid: 1774580
+
+nexus_game_id: starwarsjedisurvivor
+
+mods_path: SwGame/Content/Paks/~mods/


### PR DESCRIPTION
SW Jedi Fallen Order

The majority of mods work without any dependencies. While I did see many mods that the instructions said to drop them in the paks folder, I still went ahead and tested to see if they work if I dropped them in the ~mods folder instead. They did work. I don't know why anyone would suggest to drop their mods in the game's pak and possibly overrite an original file because something could fail and they can lose the original file. This is forshadowing that you'll see me explain later on. Something happened. Anyway, sorry for the boring rant, point is, I pointed the path to ~mods and it worked.


SW Jedi Survivor
Very few mods are made without dependencies that simply go in the default path

Most mods are "outfit mods" which needs both
Outfit Manager : https://www.nexusmods.com/starwarsjedisurvivor/mods/110?tab=description

and

R457 Mod Loader : https://www.nexusmods.com/starwarsjedisurvivor/mods/85

Neither have a github link for me to add as extensions.

Although most mods require the extensions, because there are some that don't, I still made a profile for SW Jedi Survivor. Not sure if you wanna reach out to both creators since NOMM is your baby, or if you want me to ask them.


KH3
Most mods go in the normal path.
Some mods didn't seem to work for me. Ironically I wasn't the only one having issues with the mods I couldnt load, so Im assuming that some mods might be outdted. Also the mods path is correct (it might throw you off when you read it) so dont let the path fool you.

The root folder is KINGDOM HEARTS III, but inside there is also another folder named KINGDOM HEARTS III. so the path is : KINGDOM HEARTS III/Content/Paks/~mods/


Issues :
some mods when being installed fail
nomm says :
error installation failed: name 'ngettext' is not defined.

I'm assuming it has to be something that Vortex expects but NOMM doesen't know what it is yet.

When the error happens, the profile for said game stops working and nomm cant be closed unless you click on change game, and then you cant enter the profile again unless you delete the .staging.nomm.yaml in the staging folder, then you have to manually remove the mods from the staging folder too, and because you have to delete the staging yaml, that you also have to delete the mods installed at the mod path manually.

luckily, the download folder is not affected. You can simply delete everything in the staging folder, go to nomm, and hit install again. this is a weird issue that happened to me with some mods in SW Fallen Order and KH3.

I managed to work around this by unpacking them, repacking them, and then they worked.