### PR TITLE
Let utilities add steam launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ essential-utilities: # this lets you define things such as mod loaders or essent
     source: "https://github.com/talon-d/darktideML-4linux/releases/download/1.5/darktideML-4linux1-5.zip" #the actual thing we'll need to download
     utility_path: "" # where the utility needs to be extracted to
     enable_command: "sh handle_darktide_mods.sh --enable" # any command that needs to be run (from the root of the game folder) to enable the mod loader
+    steam_launch_options: "babla" # any launch option that needs to be added to the game on Steam
 ```
 
 ## "Roadmap"

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -3,11 +3,12 @@ import shutil
 import yaml
 import subprocess
 import zipfile
+import vdf
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from datetime import datetime
-from core.tools import load_yaml, write_yaml
+from core.tools import load_yaml, write_yaml, load_user_config
 
 #TODO:Change the logic to deploy last mods from the index first
 def deploy_mod_files(staging_dir: str, dest_dir: str, mod_name: str) -> bool:
@@ -209,7 +210,6 @@ def find_text_file(mod_files: list) -> str:
             return file_path
     return ""
 
-# #dashboard.py (l:883)
 def is_utility_installed(local_zip_path: Path, target_dir: Path) -> bool:
     if not local_zip_path.exists():
         return False
@@ -219,8 +219,7 @@ def is_utility_installed(local_zip_path: Path, target_dir: Path) -> bool:
     except Exception: 
         return False
 
- # dashboard.py/execute_utility_install
-def deploy_essential_utility(util_config: dict, downloads_path: str, game_path: str):
+def deploy_essential_utility(util_config: dict, downloads_path: str, game_path: str, steam_base: str, steam_id: str):
     source_url = util_config.get("source")
     filename = source_url.split("/")[-1]
     zip_path = Path(downloads_path) / "utilities" / filename
@@ -233,6 +232,7 @@ def deploy_essential_utility(util_config: dict, downloads_path: str, game_path: 
     whitelist = util_config.get("whitelist", [])
     blacklist = util_config.get("blacklist", [])
     
+    print("Extracting utility contents")
     # TODO:Replace function with extract_archive from archive_manager
     with zipfile.ZipFile(zip_path, 'r') as z:
         if not whitelist and not blacklist:
@@ -246,11 +246,31 @@ def deploy_essential_utility(util_config: dict, downloads_path: str, game_path: 
                     continue
                 z.extract(file_info, target_dir)
 
-    cmd = util_config.get("enable_command")
-    if cmd:
-        subprocess.run(cmd, shell=True, cwd=game_root)
+    command = util_config.get("enable_command")
+    if command:
+        print(f"Running utility enable command: {command}")
+        subprocess.run(command, shell=True, cwd=game_root)
+    
+    steam_launch_options = util_config.get("steam_launch_options")
+    if steam_launch_options:
+        print(f"Adding Steam launch options: {steam_launch_options}")
+        localconfig_path = steam_base + "userdata/" + load_user_config()["steam_user_id"] + "/config/localconfig.vdf"
+        print(f"...to localconfig file located at: {localconfig_path}")
+        with open(localconfig_path, 'r') as vdf_file:
+            localconfig = vdf.load(vdf_file)
+        game_data = localconfig["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][str(steam_id)]
+        if "LaunchOptions" not in game_data:
+            localconfig["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][str(steam_id)]["LaunchOptions"] = steam_launch_options
+        else:
+            localconfig["UserLocalConfigStore"]["Software"]["Valve"]["Steam"]["apps"][str(steam_id)]["LaunchOptions"] = steam_launch_option_merger(game_data["LaunchOptions"], steam_launch_options)
+        with open(localconfig_path, 'w') as vdf_file:
+            vdf.dump(localconfig, vdf_file)
 
-# 
+def steam_launch_option_merger(current_launch_options: str, new_option: str) -> str:
+    # TODO: add some proprer logic here - notably to check if the new option being added doesn't already exist.
+    merged_launch_option = current_launch_options + " " + new_option
+    return merged_launch_option
+
 def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: str, deployment_targets: list) -> bool:
     staging_meta_path = os.path.join(staging_dir, ".staging.nomm.yaml")
     staging_metadata = load_staging_metadata(staging_meta_path)

--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -1,8 +1,10 @@
 import os
 import yaml
+import vdf
 
 from typing import List, Dict, Any
 from gi.repository import GLib, Gio
+
 
 def get_contrast_color(hex_code: str) -> str:
     hex_code = hex_code.lstrip('#')
@@ -87,3 +89,17 @@ def translate_fuse_path(folder_info) -> str:
         except GLib.Error:
             print("Can not get real path. If you see this message you will need to manually give NOMM host filesystem permissions.")
     return folder_path
+
+def get_username_from_steam_id(steam_id: str, steam_base_path) -> str:
+    localconfig_path = steam_base_path + "userdata/" + steam_id + "/config/localconfig.vdf"
+    if not os.path.exists(localconfig_path):
+        print(f"No file found at : {localconfig_path}")
+        return None
+    with open(localconfig_path, 'r') as vdf_file:
+        localconfig_data = vdf.load(vdf_file)
+    try:
+        steam_username = localconfig_data["UserLocalConfigStore"]["friends"][steam_id]["name"]
+    except ValueError:
+        print("Could not find the Steam username")
+        return None
+    return steam_username

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -10,7 +10,7 @@ gi.require_version('Notify', '0.7')
 from gi.repository import Adw, Gdk, GdkPixbuf, GLib, Gtk, Pango, Gio
 
 from core.config import update_user_config
-from core.tools import load_yaml, write_yaml, load_user_config, write_user_config, translate_fuse_path
+from core.tools import load_yaml, write_yaml, load_user_config, write_user_config, translate_fuse_path, get_username_from_steam_id
 from core.scanner import get_steam_base_dir, scan_all_games
 from gui.app_views.library_view import LibraryView
 from gui.dashboard import GameDashboard
@@ -199,13 +199,78 @@ class Nomm(Adw.Application):
         
         cont_btn = Gtk.Button(label=_("Continue"))
         cont_btn.add_css_class("suggested-action")
-        cont_btn.connect("clicked", lambda b: self.finalize_setup(self.api_entry.get_text()))
+        cont_btn.connect("clicked", lambda b: self.store_api_key(self.api_entry.get_text()))
         entry_box.append(self.api_entry); entry_box.append(cont_btn)
         status_page.set_child(entry_box)
         self.stack.add_named(status_page, "api_key"); self.stack.set_visible_child_name("api_key")
 
-    def finalize_setup(self, api_key):
+    def store_api_key(self, api_key):
         self.temp_config["nexus_api_key"] = api_key
+        self.steam_user_id_handler()
+
+    def steam_user_id_handler(self):
+        steam_userdata_path = self.steam_base + "userdata/"
+        steam_user_ids = [f for f in os.listdir(steam_userdata_path) if os.path.isdir(os.path.join(steam_userdata_path, f))]
+        steam_user_ids.remove("0")
+        print(f"Steam user IDs detected: {steam_user_ids}")
+        if len(steam_user_ids) > 1:
+            self.show_steam_user_id_selection_screen(steam_user_ids)
+        else:
+            steam_user_id = steam_user_ids[0]
+            self.temp_config["steam_user_id"] = steam_user_id
+            self.finalize_setup()
+
+    def show_steam_user_id_selection_screen(self, steam_user_ids):
+        status_page = Adw.StatusPage(
+            title=_("Select Your Steam user ID"),
+            description=_("Multiple Steam user IDs were detected in your Steam installation.\n"
+            "Please select the one that you want to configure when using NOMM."),
+        )
+
+        # Usage in your StatusPage:
+        icon_path = self.assets_path + "/platform_logos/steam_logo.svg"
+        file_obj = Gio.File.new_for_path(icon_path)
+        paintable = Gtk.IconPaintable.new_for_file(file_obj, 128, 1) # file, size, scale
+        status_page.set_paintable(paintable)
+
+        # Create a boxed list for the options
+        list_box = Gtk.ListBox()
+        list_box.add_css_class("boxed-list")
+        list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        list_box.set_valign(Gtk.Align.START)
+
+
+        options = []
+        for steam_user_id in steam_user_ids:
+            options.append({
+                "id": steam_user_id,
+                "username": get_username_from_steam_id(steam_user_id, self.steam_base)})
+
+
+        for opt in options:
+            row = Adw.ActionRow(title=opt["id"], subtitle=opt["username"])
+            row.set_activatable(True)
+            # Connect the row to a callback
+            row.connect("activated", self.on_option_selected, opt["id"])
+            list_box.append(row)
+
+        # Wrap the list in a box for padding/alignment
+        container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
+        container.set_halign(Gtk.Align.CENTER)
+        container.set_margin_top(24)
+        container.append(list_box)
+
+        status_page.set_child(container)
+        self.stack.add_titled(status_page, "option_select", _("Select Option"))
+        self.stack.set_visible_child_name("option_select")
+
+    def on_option_selected(self, row, steam_user_id):
+        print(f"User's Steam user ID set to: {steam_user_id}")
+        self.temp_config["steam_user_id"] = steam_user_id
+        # Continue to next part of setup
+        self.finalize_setup()
+
+    def finalize_setup(self):
         write_yaml(self.temp_config, self.user_config_path)
         self.show_loading_and_scan()
 

--- a/src/gui/dashboard.py
+++ b/src/gui/dashboard.py
@@ -34,6 +34,7 @@ class GameDashboard(Gtk.Box):
         self.app_id = app_id
         self.current_filter = "all"
         self.active_tab = "mods"
+        self.steam_base = steam_base
         self.assets_path = assets_path
         self.game_config = load_yaml(game_config_path)
         self.user_config = load_yaml(user_config_path)

--- a/src/gui/dashboard_views/tools_tab.py
+++ b/src/gui/dashboard_views/tools_tab.py
@@ -136,7 +136,7 @@ class ToolsTab(Gtk.Box):
 
     def execute_utility_install(self, util):
         try:
-            deploy_essential_utility(util, self.dashboard.downloads_path, self.dashboard.game_path)
+            deploy_essential_utility(util, self.dashboard.downloads_path, self.dashboard.game_path, self.dashboard.steam_base, self.dashboard.game_config.get("steam_id"))
             
             self.dashboard.show_message(
                 _("Success"),

--- a/src/gui/dashboard_views/tools_tab.py
+++ b/src/gui/dashboard_views/tools_tab.py
@@ -114,16 +114,68 @@ class ToolsTab(Gtk.Box):
 
         download_file_async(source_url, util_dir, on_success, on_error)
 
-    def on_utility_install_clicked(self, btn, util):
-        msg = _("Warning: This process may be destructive to existing game files. Please ensure you have backed up your game directory before proceeding.")
+    def on_utility_install_clicked(self, btn, util: dict):
+        # Base warning message
+        msg = _("This process may replace existing game files. Please ensure you have backed up your game directory before proceeding.")
         
         dialog = Adw.MessageDialog(
             transient_for=self.dashboard.app.win,
-            heading=_("Confirm Installation"),
-            body=msg
+            heading=_("Confirm Installation")
         )
+        
+        dialog.set_default_size(500, -1)
+
+        # Container for the body content
+        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        
+        # Primary warning label
+        warning_label = Gtk.Label(label=msg, wrap=True, xalign=0)
+        content_box.append(warning_label)
+
+        # Check if steam_launch_options exist in the util dict
+        launch_options = util.get("steam_launch_options")
+        if launch_options:
+            separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+            separator.set_margin_top(8)
+            separator.set_margin_bottom(8)
+            content_box.append(separator)
+
+            # Additional instruction text
+            instruction_text = _("This utility requires the game to have extra Steam launch options.\n"
+                                 "NOMM is able to add these for you but <b>Steam needs to be turned off</b>.")
+            instruction_label = Gtk.Label(label=instruction_text, wrap=True, xalign=0)
+            instruction_label.set_use_markup(True)
+            content_box.append(instruction_label)
+
+            # The code box with copy button
+            code_bin = Adw.Bin()
+            code_bin.add_css_class("card") # Gives it the boxed look
+
+            code_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            code_box.set_margin_start(12); code_box.set_margin_end(6)
+            code_box.set_margin_top(6); code_box.set_margin_bottom(6)
+
+            options_label = Gtk.Label(label=launch_options, selectable=True, xalign=0)
+            options_label.add_css_class("monospace")
+            
+            copy_btn = Gtk.Button(icon_name="edit-copy-symbolic")
+            copy_btn.set_tooltip_text(_("Copy to Clipboard"))
+            copy_btn.add_css_class("flat")
+            copy_btn.connect("clicked", self.dashboard.app.copy_to_clipboard, launch_options)
+
+            code_box.append(options_label)
+            code_box.set_hexpand(True)
+            options_label.set_hexpand(True)
+            code_box.append(copy_btn)
+            
+            code_bin.set_child(code_box)
+            content_box.append(code_bin)
+
+        # Set the custom box as the extra child of the dialog
+        dialog.set_extra_child(content_box)
+        
         dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("install", _("Install Anyway"))
+        dialog.add_response("install", _("Continue"))
         dialog.set_response_appearance("install", Adw.ResponseAppearance.DESTRUCTIVE)
         
         def on_response(d, response_id):


### PR DESCRIPTION
Sometimes utilities need to add special steam launch options for the game that is being modded.
It is now possible to add this to a game_config.yaml.
For NOMM to be able to add the launch options to Steam, it needs the user's Steam ID.

NOMM is able to check Steam files for existing user IDs, but sometimes users can have multiple accounts on the same computer.

In those cases, NOMM will therefore ask the user which user ID corresponds to theirs during initial setup.
This information is then used so that NOMM can make changes to the localconfig.vdf file which stores information relating to games including game launch options.

**It is important to note that this file is only read by Steam at startup, and it is written to by Steam at shutdown, so if NOMM is to be used to change those values, it has to be done when Steam is turned off, or those values will be overwritten by Steam**

As a precaution, a warning was added to the existing popup when clicking to install a utility.
There is also an option for the user to copy the required steam launch options themselves and add them manually via the Steam interface.