### PR TITLE
Small changes to mod order logic + deploy mod logic

### DIFF
--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -11,8 +11,7 @@ import vdf
 import yaml
 from gi.repository import GLib
 
-from core.tools import load_yaml, write_yaml
-from core.user_config import load_user_config
+from core.tools import load_yaml, write_yaml, load_user_config
 
 meta_lock = threading.Lock()
 

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -1,33 +1,33 @@
 import os
 import shutil
-import yaml
-import threading
 import subprocess
+import threading
 import zipfile
-import vdf
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
-from datetime import datetime
-from core.tools import load_yaml, write_yaml, load_user_config
+
+import vdf
+import yaml
+from gi.repository import GLib
+
+from core.tools import load_yaml, write_yaml
+from core.user_config import load_user_config
 
 meta_lock = threading.Lock()
 
-#TODO:Change the logic to deploy last mods from the index first
-def deploy_mod_files(staging_dir: str, dest_dir: str, mod_name: str) -> bool:
+def deploy_mod_files(staging_dir: str, dest_dir: str, mod_files: list, mod_name: str) -> bool:
     dest_path = Path(dest_dir)
-    staging_mod_path = os.path.join(Path(staging_dir), mod_name)
     
     staging_meta_path = os.path.join(Path(staging_dir), ".staging.nomm.yaml")
     staging_metadata = load_staging_metadata(staging_meta_path)
     
-    mod_info = staging_metadata["mods"][mod_name]
-    mod_files = mod_info.get("mod_files", [])
+    staging_mod_dir = Path(staging_dir) / mod_name
     
     is_success = True
 
     for mod_file in mod_files:
-        source_item = Path(staging_mod_path) / mod_file
+        source_item = Path(staging_mod_dir) / mod_file
         link_item = Path(dest_path) / mod_file
 
         if not source_item.exists():
@@ -54,54 +54,19 @@ def deploy_mod_files(staging_dir: str, dest_dir: str, mod_name: str) -> bool:
             try:
                 # symlink
                 os.symlink(source_item, link_item)
+                print(f"[+] Successfully linked {source_item}")
             except Exception as sym_e:
                 print(f"Error creating a Symlink {link_item}: {sym_e}")
                 is_success = False
     
-    # Update game status
-    if not is_success:
-        unlink_mod_files(staging_mod_path, dest_dir, mod_files)
+    if is_success == False: 
+        unlink_mod_files(staging_dir, dest_dir, mod_files)
         staging_metadata["mods"][mod_name]["status"] = "disabled"
-        mod_info.pop("enabled_timestamp", None)
+        staging_metadata["mods"][mod_name].pop("enabled_timestamp", None)
         write_yaml(staging_metadata, staging_meta_path)
         return is_success
-    
     return is_success
 
-# Just a loop that deploy mods following the index list
-def deploy_all_ordered_mods(staging_dir: str, dest_dir: str) -> bool:
-    staging_meta_path = os.path.join(staging_dir, ".staging.nomm.yaml")
-    indexed_mods = read_index(staging_meta_path)
-    staging_metadata = load_staging_metadata(staging_meta_path)
-    
-    for mod_name in staging_metadata["mods"]:
-        if staging_metadata["mods"][mod_name]["status"] == "enabled":
-            staging_mod_path = os.path.join(staging_dir, mod_name)
-            unlink_mod_files(staging_mod_path, dest_dir, staging_metadata["mods"][mod_name].get("mod_files"))
-    
-    # Loop from item in index metadata, first on the list is deployed first etc...
-    error_count = 0
-    for mod_name in indexed_mods:
-        if mod_name in staging_metadata.get("mods", {}):
-            mod_info = staging_metadata["mods"][mod_name]
-            if mod_info.get("status") == "enabled":
-                if not deploy_mod_files(
-                    staging_dir,
-                    dest_dir,
-                    mod_name
-                ):
-                    error_count += 1
-    if error_count:
-        show_message(_("Error"), _("Installation failed: {}"))
-        show_message(_("Error"), ngettext(
-                    "{} installation failed, see logs for more details",
-                    "{} installations failed, see logs for more details",
-                    error_count)
-                )
-        return False
-    return True
-
-# dashboard.py/update_indicators with available downloads and mods grouped but logic is the same
 def get_mod_statistics(staging_meta_path: str, downloads_path: str) -> dict:
     # Dictionary is initialized here
     stats = {
@@ -150,7 +115,7 @@ def is_mod_installed(archive_filename, staging_metadata) -> bool:
 def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
     dest_path = Path(dest_dir)
     staging_path = Path(staging_dir)
-
+    
     for mod_file in mod_files:
         link_item = dest_path / mod_file
         source_item = staging_path / mod_file
@@ -162,6 +127,7 @@ def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
             try:
                 if os.path.samefile(source_item, link_item):
                     link_item.unlink()
+                    print(f"[-] Successfully unlinked {source_item}")
             except Exception as e:
                 print(f"Failed to unlink {link_item}: {e}")
 
@@ -203,10 +169,92 @@ def check_for_conflicts(staging_meta_path: str) -> list:
             unique_mods = sorted(list(set(mod_list)))
             if unique_mods not in conflicts:
                 conflicts.append(unique_mods)
-
+    
     return conflicts
 
-# Dashboard.py/find_text_file
+def build_deployment_map(staging_metadata_path: str) -> dict:
+    deployment_map = {}
+    staging_metadata = load_staging_metadata(staging_metadata_path)
+
+    if not staging_metadata:
+        return []
+    
+    mod_index = staging_metadata["index"]
+    
+    for mod in reversed(mod_index):
+        if staging_metadata["mods"][mod].get("status") == 'enabled':
+            for file_path in staging_metadata["mods"][mod].get("mod_files", []):
+                if file_path not in deployment_map:
+                    deployment_map[file_path] = mod
+    
+    return deployment_map
+
+def check_for_deployment_map_change(new_deployment_map: dict, current_deployment_map: dict) -> list:
+    # Initialize a dict
+    changes = {
+        'additions': {},
+        'deletions': {}
+    }
+    
+    for file in new_deployment_map:
+        if file not in current_deployment_map or current_deployment_map.get(file) != new_deployment_map.get(file) :
+            additional_change = {
+                'current_source' : current_deployment_map.get(file), 
+                'new_source' : new_deployment_map.get(file)
+            }
+            changes['additions'][file] = additional_change
+            
+    for file in current_deployment_map:
+        if file not in new_deployment_map:
+            changes['deletions'][file] = current_deployment_map.get(file)
+    
+    return changes
+
+def apply_deployment_map_changes(staging_dir: str, dest_dir: str, changes: dict, mod_name: str) -> bool:
+    files_to_unlink = {}
+    files_to_link = {}
+    
+    # Apply additions
+    for change in changes['additions']:
+        deleting_mod_name = changes['additions'][change].get('current_source')
+        deploying_mod_name = changes['additions'][change].get('new_source')
+        
+        if deleting_mod_name:
+            if not files_to_unlink.get(deleting_mod_name, []):
+                files_to_unlink[deleting_mod_name] = []
+            files_to_unlink[deleting_mod_name].append(change)
+        
+        if not files_to_link.get(deploying_mod_name, []):
+            files_to_link[deploying_mod_name] = []
+        
+        files_to_link[deploying_mod_name].append(change)
+    
+    # Apply deletions
+    for file in changes['deletions']:
+        deploying_mod_name = changes['deletions'][file]
+        if not files_to_unlink.get(deploying_mod_name, []):
+            files_to_unlink[deploying_mod_name] = []    
+        
+        files_to_unlink[deploying_mod_name].append(file)
+    
+    # Starts unlinking files
+    def unlink_files(staging_dir, dest_dir, files_to_unlink, files_to_link):
+        for mod in files_to_unlink:
+            staging_mod_dir = Path(staging_dir) / mod
+            unlink_mod_files(staging_mod_dir, dest_dir, files_to_unlink[mod])
+        GLib.idle_add(on_unlink_finish, staging_dir, dest_dir, files_to_link)
+    
+    # Starts deploying files
+    def on_unlink_finish(staging_dir, dest_dir, files_to_link):
+        for mod in files_to_link:
+            if deploy_mod_files(staging_dir, dest_dir, files_to_link[mod], mod) == False:
+                print(f"Error while deploying: {mod}")
+                return False
+    
+    threading.Thread(target=unlink_files, args=(staging_dir, dest_dir, files_to_unlink, files_to_link), daemon=True).start()
+    
+    return True
+
 def find_text_file(mod_files: list) -> str:
     for file_path in mod_files:
         if ".txt" in file_path:
@@ -274,7 +322,7 @@ def steam_launch_option_merger(current_launch_options: str, new_option: str) -> 
     merged_launch_option = current_launch_options + " " + new_option
     return merged_launch_option
 
-def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: str, deployment_targets: list) -> bool:
+def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: str, deployment_targets: list, deployment_map: list) -> dict:
     staging_meta_path = os.path.join(staging_dir, ".staging.nomm.yaml")
     dest_dir = deployment_targets[0]["path"]
     
@@ -292,7 +340,11 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
                     break
 
         staging_mod_dir = os.path.join(staging_dir, mod_name)
-
+        
+        mod_files = mod_info.get("mod_files", [])
+            
+        success = False
+        
         # state is true so the mod has to be installed/deployed
         if state:
             # deploy_mod_files return true if it worked, false if it doesn't
@@ -300,9 +352,14 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             mod_info["enabled_timestamp"] = datetime.now()
             write_yaml(staging_metadata, staging_meta_path)
             if check_for_conflicts(staging_meta_path):
-                success = deploy_all_ordered_mods(staging_dir, dest_dir)
+                new_deployment_map = build_deployment_map(staging_meta_path)
+                if deployment_map != new_deployment_map:
+                    changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
+                    success = apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
+                else:
+                    success = True
             else:
-                success = deploy_mod_files(staging_dir, dest_dir, mod_name)
+                success = deploy_mod_files(staging_dir, dest_dir, mod_files)
             if success:
                 #TODO: Remove status data as there already is a timestamp
                 print(f"Successfully deployed mod: {mod_name}")
@@ -310,14 +367,16 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             return False
         # state is false, deleting the datas and ensure metadata are set to proper value
         else:
-            unlink_mod_files(staging_mod_dir, dest_dir, mod_files)
             mod_info["status"] = "disabled"
             # Pop is a safety measure to prevent a crash for a missing key
             mod_info.pop("enabled_timestamp", None)
             write_yaml(staging_metadata, staging_meta_path)
+            # Recalculating mod files
+            new_deployment_map = build_deployment_map(staging_meta_path)
+            if deployment_map != new_deployment_map:
+                changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
+                apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
             # If there is a conflict mods have to be reloaded in case you unloaded a mod that did an override
-            if check_for_conflicts(staging_meta_path):
-                success = deploy_all_ordered_mods(staging_dir, dest_dir)
             return True
 
 # method to get the metadata path that is used everywhere in the app

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -1,17 +1,19 @@
 import gettext
 import os
-import webbrowser
 import threading
+import webbrowser
 from datetime import datetime
 from pathlib import Path
 
-from gi.repository import Adw, Gdk, GLib, GObject, Gtk, Gio, GdkPixbuf
+from gi.repository import Adw, Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk
 
-from core.mod_manager import (change_mod_index, check_for_conflicts,
-                              deploy_all_ordered_mods, load_staging_metadata,
-                              read_index, toggle_mod_state)
+from core.mod_manager import (apply_deployment_map_changes, build_deployment_map,
+                              change_mod_index, check_for_conflicts,
+                              check_for_deployment_map_change,
+                              load_staging_metadata, read_index,
+                              toggle_mod_state)
 from core.nexus_api import check_for_mod_updates_async
-from core.tools import timestamp_converter, write_yaml, process_bbcode
+from core.tools import process_bbcode, timestamp_converter, write_yaml
 
 _ = gettext.gettext
 ngettext = gettext.ngettext
@@ -24,6 +26,9 @@ class ModsTab(Gtk.Box):
         self.set_margin_top(20)
         
         self.dashboard = dashboard
+        
+        # Deployment map is used to redeploy files while moving items
+        self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
         
         # Action bar top right
         action_bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -404,11 +409,14 @@ class ModsTab(Gtk.Box):
                 mod_files=mod_files,
                 state=state,
                 staging_dir=str(self.dashboard.staging_path),
-                deployment_targets=self.dashboard.deployment_targets
+                deployment_targets=self.dashboard.deployment_targets,
+                deployment_map=self.deployment_map
             )
             GLib.idle_add(on_toggle_done, success)
             
         def on_toggle_done(success):
+            if success:
+                self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
             # UI Fallback if toggle fail
             self.dashboard.currently_toggling.discard(mod)
             switch.set_sensitive(True)
@@ -446,7 +454,15 @@ class ModsTab(Gtk.Box):
         if mod_name in current_mods:
             target_index = current_mods.index(mod_name)
             change_mod_index(self.dashboard.staging_metadata_path, value, target_index)
-            deploy_all_ordered_mods(self.dashboard.staging_path, dest_dir)
+            
+            # Redeploy the files that changed
+            new_deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
+            if new_deployment_map != self.deployment_map:
+                changes = check_for_deployment_map_change(new_deployment_map, self.deployment_map)
+                apply_deployment_map_changes(self.dashboard.staging_path, dest_dir, changes, mod_name)
+                self.deployment_map = new_deployment_map
+            
+            # Refresh UI
             self.populate_list()
             return True
         return False


### PR DESCRIPTION
The main goal was to entirely remove the deploy_all_ordered_mods which was CPU demanding with heavy mod lists. This has been made possible thanks to new methods :

Build_deployment_map binds a mod to each file in a dictionary

Check_for_deployment_map_changes is pretty self explanatory : it compares two deployment maps and return the additions and deletions that has been made

Apply_deployment_map_changes unlink files that have to be replaced then link the new files if needed from the change list.

We could also make these changes safer to use and create a new method that cycles through them properly so we don't have to always use them one after the other.