### PR TITLE
Quick fix/heavy performance improvement for mod index

### DIFF
--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -185,10 +185,8 @@ def build_deployment_map(staging_metadata: dict) -> dict:
     if not staging_metadata:
         return []
     
-    mod_index = staging_metadata["index"]
-    
     deployment_map = {}
-    for mod in reversed(mod_index):
+    for mod in reversed(staging_metadata["index"]):
         if "enabled_timestamp" in staging_metadata["mods"][mod]:
             for file_path in staging_metadata["mods"][mod].get("mod_files", []):
                 if file_path not in deployment_map:
@@ -197,7 +195,6 @@ def build_deployment_map(staging_metadata: dict) -> dict:
     return deployment_map
 
 def check_for_deployment_map_change(new_deployment_map: dict, current_deployment_map: dict) -> list:
-    # Initialize a dict
     changes = {
         'additions': {},
         'deletions': {}

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -353,7 +353,7 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             
         success = True
         
-        conflicts_exists = check_for_conflicts(staging_meta_path)
+        conflicts_exist = check_for_conflicts(staging_meta_path)
         
         new_deployment_map = {}
 
@@ -364,7 +364,7 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             mod_info["status"] = "enabled"
             mod_info["enabled_timestamp"] = datetime.now()
             write_yaml(staging_metadata, staging_meta_path)
-            if conflicts_exists:
+            if conflicts_exist:
                 new_deployment_map = build_deployment_map(staging_metadata)
                 if deployment_map != new_deployment_map:
                     changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
@@ -383,7 +383,7 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             mod_info.pop("enabled_timestamp", None)
             write_yaml(staging_metadata, staging_meta_path)
             # If there is a conflict mods have to be reloaded in case you unloaded a mod that did an override
-            if conflicts_exists:
+            if conflicts_exist:
                 # Recalculating mod files
                 new_deployment_map = build_deployment_map(staging_metadata)
                 if deployment_map != new_deployment_map:
@@ -398,7 +398,7 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
                     success = False
         
         # Update deployment map
-        if success and conflicts_exists:
+        if success and conflicts_exist:
             deployment_map = new_deployment_map
         
         deployment_output = {

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -362,7 +362,7 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
                 else:
                     success = True
             else:
-                success = deploy_mod_files(staging_dir, dest_dir, mod_file, mod_name)
+                success = deploy_mod_files(staging_dir, dest_dir, mod_info["mod_files"], mod_name)
             if success:
                 #TODO: Remove status data as there already is a timestamp
                 print(f"Successfully deployed mod: {mod_name}")

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -9,27 +9,26 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from datetime import datetime
+from gi.repository import GLib
 from core.tools import load_yaml, write_yaml, load_user_config
 
 meta_lock = threading.Lock()
 
 #TODO:Change the logic to deploy last mods from the index first
-def deploy_mod_files(staging_dir: str, dest_dir: str, mod_info: dict) -> bool:
+def deploy_mod_files(staging_dir: str, dest_dir: str, mod_files: list, mod_name: str) -> bool:
     dest_path = Path(dest_dir)
-    
-    mod_name = mod_info.get("folder_name", mod_info.get("display_name", mod_info.get("name")))
-
-    staging_mod_path = os.path.join(Path(staging_dir), mod_name)
     
     staging_meta_path = os.path.join(Path(staging_dir), ".staging.nomm.yaml")
     staging_metadata = load_staging_metadata(staging_meta_path)
     
-    mod_files = mod_info.get("mod_files", [])
+    folder_name=staging_metadata["mods"][mod_name].get("folder_name", staging_metadata["mods"][mod_name].get("display_name"))
+
+    staging_mod_dir = Path(staging_dir) / folder_name
     
     is_success = True
 
     for mod_file in mod_files:
-        source_item = Path(staging_mod_path) / mod_file
+        source_item = Path(staging_mod_dir) / mod_file
         link_item = Path(dest_path) / mod_file
 
         if not source_item.exists():
@@ -56,52 +55,20 @@ def deploy_mod_files(staging_dir: str, dest_dir: str, mod_info: dict) -> bool:
             try:
                 # symlink
                 os.symlink(source_item, link_item)
+                print(f"[+] Successfully linked {source_item}")
             except Exception as sym_e:
                 print(f"Error creating a Symlink {link_item}: {sym_e}")
                 is_success = False
     
     # Update game status
     if not is_success:
-        unlink_mod_files(staging_mod_path, dest_dir, mod_files)
+        unlink_mod_files(staging_mod_dir, dest_dir, mod_files)
         staging_metadata["mods"][mod_name]["status"] = "disabled"
-        mod_info.pop("enabled_timestamp", None)
+        staging_metadata["mods"][mod_name].pop("enabled_timestamp", None)
         write_yaml(staging_metadata, staging_meta_path)
         return is_success
     
     return is_success
-
-# Just a loop that deploy mods following the index list
-def deploy_all_ordered_mods(staging_dir: str, dest_dir: str) -> bool:
-    staging_meta_path = os.path.join(staging_dir, ".staging.nomm.yaml")
-    indexed_mods = read_index(staging_meta_path)
-    staging_metadata = load_staging_metadata(staging_meta_path)
-    
-    for mod_name in staging_metadata["mods"]:
-        if staging_metadata["mods"][mod_name]["status"] == "enabled":
-            staging_mod_path = os.path.join(staging_dir, mod_name)
-            unlink_mod_files(staging_mod_path, dest_dir, staging_metadata["mods"][mod_name].get("mod_files"))
-    
-    # Loop from item in index metadata, first on the list is deployed first etc...
-    error_count = 0
-    for mod_name in indexed_mods:
-        if mod_name in staging_metadata.get("mods", {}):
-            mod_info = staging_metadata["mods"][mod_name]
-            if mod_info.get("status") == "enabled":
-                if not deploy_mod_files(
-                    staging_dir,
-                    dest_dir,
-                    mod_info
-                ):
-                    error_count += 1
-    if error_count:
-        show_message(_("Error"), _("Installation failed: {}"))
-        show_message(_("Error"), ngettext(
-                    "{} installation failed, see logs for more details",
-                    "{} installations failed, see logs for more details",
-                    error_count)
-                )
-        return False
-    return True
 
 # dashboard.py/update_indicators with available downloads and mods grouped but logic is the same
 def get_mod_statistics(staging_meta_path: str, downloads_path: str) -> dict:
@@ -164,6 +131,7 @@ def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
             try:
                 if os.path.samefile(source_item, link_item):
                     link_item.unlink()
+                    print(f"[-] Successfully unlinked {source_item}")
             except Exception as e:
                 print(f"Failed to unlink {link_item}: {e}")
 
@@ -207,6 +175,92 @@ def check_for_conflicts(staging_meta_path: str) -> list:
                 conflicts.append(unique_mods)
 
     return conflicts
+
+def build_deployment_map(staging_metadata_path: str) -> dict:
+    deployment_map = {}
+    staging_metadata = load_staging_metadata(staging_metadata_path)
+
+    if not staging_metadata:
+        return []
+    
+    mod_index = staging_metadata["index"]
+    
+    for mod in reversed(mod_index):
+        if staging_metadata["mods"][mod].get("status") == 'enabled':
+            for file_path in staging_metadata["mods"][mod].get("mod_files", []):
+                if file_path not in deployment_map:
+                    deployment_map[file_path] = mod
+    
+    return deployment_map
+
+def check_for_deployment_map_change(new_deployment_map: dict, current_deployment_map: dict) -> list:
+    # Initialize a dict
+    changes = {
+        'additions': {},
+        'deletions': {}
+    }
+    
+    for file in new_deployment_map:
+        if file not in current_deployment_map or current_deployment_map.get(file) != new_deployment_map.get(file) :
+            additional_change = {
+                'current_source' : current_deployment_map.get(file), 
+                'new_source' : new_deployment_map.get(file)
+            }
+            changes['additions'][file] = additional_change
+            
+    for file in current_deployment_map:
+        if file not in new_deployment_map:
+            changes['deletions'][file] = current_deployment_map.get(file)
+    
+    return changes
+
+def apply_deployment_map_changes(staging_dir: str, dest_dir: str, changes: dict, mod_name: str) -> bool:
+    files_to_unlink = {}
+    files_to_link = {}
+    
+    # Apply additions
+    for change in changes['additions']:
+        deleting_mod_name = changes['additions'][change].get('current_source')
+        deploying_mod_name = changes['additions'][change].get('new_source')
+        
+        if deleting_mod_name:
+            if not files_to_unlink.get(deleting_mod_name, []):
+                files_to_unlink[deleting_mod_name] = []
+            files_to_unlink[deleting_mod_name].append(change)
+        
+        if not files_to_link.get(deploying_mod_name, []):
+            files_to_link[deploying_mod_name] = []
+        
+        files_to_link[deploying_mod_name].append(change)
+    
+    # Apply deletions
+    for file in changes['deletions']:
+        deploying_mod_name = changes['deletions'][file]
+        if not files_to_unlink.get(deploying_mod_name, []):
+            files_to_unlink[deploying_mod_name] = []    
+        
+        files_to_unlink[deploying_mod_name].append(file)
+    
+    # Starts unlinking files
+    def unlink_files(staging_dir, dest_dir, files_to_unlink, files_to_link):
+        metadata = load_staging_metadata(os.path.join(staging_dir, ".staging.nomm.yaml"))
+        for mod in files_to_unlink:
+            mod_info = metadata["mods"].get(mod, {})
+            folder_name = mod_info.get("folder_name", mod_info.get("display_name", mod))
+            staging_mod_dir = Path(staging_dir) / folder_name
+            unlink_mod_files(staging_mod_dir, dest_dir, files_to_unlink[mod])
+        GLib.idle_add(on_unlink_finish, staging_dir, dest_dir, files_to_link)
+    
+    # Starts deploying files
+    def on_unlink_finish(staging_dir, dest_dir, files_to_link):
+        for mod in files_to_link:
+            if deploy_mod_files(staging_dir, dest_dir, files_to_link[mod], mod) == False:
+                print(f"Error while deploying: {mod}")
+                return False
+    
+    threading.Thread(target=unlink_files, args=(staging_dir, dest_dir, files_to_unlink, files_to_link), daemon=True).start()
+    
+    return True
 
 # Dashboard.py/find_text_file
 def find_text_file(mod_files: list) -> str:
@@ -276,7 +330,7 @@ def steam_launch_option_merger(current_launch_options: str, new_option: str) -> 
     merged_launch_option = current_launch_options + " " + new_option
     return merged_launch_option
 
-def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: str, deployment_targets: list) -> bool:
+def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: str, deployment_targets: list, deployment_map: list) -> dict:
     staging_meta_path = os.path.join(staging_dir, ".staging.nomm.yaml")
     dest_dir = deployment_targets[0]["path"]
     
@@ -291,17 +345,24 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             dest_dir = mod_info["deployment_path"]
 
         staging_mod_dir = os.path.join(staging_dir, mod_name)
+        mod_files = mod_info.get("mod_files", [])
+            
+        success = False
 
         # state is true so the mod has to be installed/deployed
         if state:
-            # deploy_mod_files return true if it worked, false if it doesn't
             mod_info["status"] = "enabled"
             mod_info["enabled_timestamp"] = datetime.now()
             write_yaml(staging_metadata, staging_meta_path)
             if check_for_conflicts(staging_meta_path):
-                success = deploy_all_ordered_mods(staging_dir, dest_dir)
+                new_deployment_map = build_deployment_map(staging_meta_path)
+                if deployment_map != new_deployment_map:
+                    changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
+                    success = apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
+                else:
+                    success = True
             else:
-                success = deploy_mod_files(staging_dir, dest_dir, mod_info)
+                success = deploy_mod_files(staging_dir, dest_dir, mod_file, mod_name)
             if success:
                 #TODO: Remove status data as there already is a timestamp
                 print(f"Successfully deployed mod: {mod_name}")
@@ -309,14 +370,15 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
             return False
         # state is false, deleting the datas and ensure metadata are set to proper value
         else:
-            unlink_mod_files(staging_mod_dir, dest_dir, mod_files)
             mod_info["status"] = "disabled"
             # Pop is a safety measure to prevent a crash for a missing key
             mod_info.pop("enabled_timestamp", None)
             write_yaml(staging_metadata, staging_meta_path)
-            # If there is a conflict mods have to be reloaded in case you unloaded a mod that did an override
-            if check_for_conflicts(staging_meta_path):
-                success = deploy_all_ordered_mods(staging_dir, dest_dir)
+            # Recalculating mod files
+            new_deployment_map = build_deployment_map(staging_meta_path)
+            if deployment_map != new_deployment_map:
+                changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
+                apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
             return True
 
 # method to get the metadata path that is used everywhere in the app

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -115,11 +115,12 @@ def is_mod_installed(archive_filename, staging_metadata) -> bool:
     return False
 
 # Checks if mod files from staging and dest folders are the same and remove the symlink if they are
-# dashboard.py (l: 1069)
-def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
+def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]) -> bool:
     dest_path = Path(dest_dir)
     staging_path = Path(staging_dir)
-
+    
+    success = True
+    
     for mod_file in mod_files:
         link_item = dest_path / mod_file
         source_item = staging_path / mod_file
@@ -133,6 +134,7 @@ def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
                     link_item.unlink()
                     print(f"[-] Successfully unlinked {source_item}")
             except Exception as e:
+                success = False
                 print(f"Failed to unlink {link_item}: {e}")
 
         current_dir = link_item.parent
@@ -142,6 +144,8 @@ def unlink_mod_files(staging_dir: str, dest_dir: str, mod_files: list[str]):
             except OSError:
                 break
             current_dir = current_dir.parent
+    
+    return success
 
 # Previous function + delete mod from staging folder
 def completely_uninstall_mod(staging_dir: str, dest_dir: str, mod_files: list[str]):
@@ -176,17 +180,16 @@ def check_for_conflicts(staging_meta_path: str) -> list:
 
     return conflicts
 
-def build_deployment_map(staging_metadata_path: str) -> dict:
-    deployment_map = {}
-    staging_metadata = load_staging_metadata(staging_metadata_path)
-
+def build_deployment_map(staging_metadata: dict) -> dict:
+    
     if not staging_metadata:
         return []
     
     mod_index = staging_metadata["index"]
     
+    deployment_map = {}
     for mod in reversed(mod_index):
-        if staging_metadata["mods"][mod].get("status") == 'enabled':
+        if "enabled_timestamp" in staging_metadata["mods"][mod]:
             for file_path in staging_metadata["mods"][mod].get("mod_files", []):
                 if file_path not in deployment_map:
                     deployment_map[file_path] = mod
@@ -341,45 +344,72 @@ def toggle_mod_state(mod_name: str, mod_files: list, state: bool, staging_dir: s
         
         mod_info = staging_metadata["mods"][mod_name]
 
-        if "deployment_path" in mod_info:
-            dest_dir = mod_info["deployment_path"]
+        if "deployment_target" in mod_info:
+            for target in deployment_targets:
+                if target["name"] == mod_info["deployment_target"]:
+                    dest_dir = target["path"]
+                    break
 
         staging_mod_dir = os.path.join(staging_dir, mod_name)
+        
         mod_files = mod_info.get("mod_files", [])
             
-        success = False
+        success = True
+        
+        conflicts_exists = check_for_conflicts(staging_meta_path)
+        
+        new_deployment_map = {}
 
         # state is true so the mod has to be installed/deployed
         if state:
+            # deploy_mod_files return true if it worked, false if it doesn't
+            #TODO: Remove status data as there already is a timestamp
             mod_info["status"] = "enabled"
             mod_info["enabled_timestamp"] = datetime.now()
             write_yaml(staging_metadata, staging_meta_path)
-            if check_for_conflicts(staging_meta_path):
-                new_deployment_map = build_deployment_map(staging_meta_path)
+            if conflicts_exists:
+                new_deployment_map = build_deployment_map(staging_metadata)
                 if deployment_map != new_deployment_map:
                     changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
                     success = apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
-                else:
-                    success = True
             else:
-                success = deploy_mod_files(staging_dir, dest_dir, mod_info["mod_files"], mod_name)
-            if success:
-                #TODO: Remove status data as there already is a timestamp
-                print(f"Successfully deployed mod: {mod_name}")
-                return True
-            return False
+                if deploy_mod_files(staging_dir, dest_dir, mod_files, mod_name):
+                    for mod_file in mod_files:
+                        deployment_map[mod_file] = mod_name
+                    print(f"Successfully deployed mod: {mod_name}")
+                else:
+                    success = False
         # state is false, deleting the datas and ensure metadata are set to proper value
         else:
             mod_info["status"] = "disabled"
             # Pop is a safety measure to prevent a crash for a missing key
             mod_info.pop("enabled_timestamp", None)
             write_yaml(staging_metadata, staging_meta_path)
-            # Recalculating mod files
-            new_deployment_map = build_deployment_map(staging_meta_path)
-            if deployment_map != new_deployment_map:
-                changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
-                apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
-            return True
+            # If there is a conflict mods have to be reloaded in case you unloaded a mod that did an override
+            if conflicts_exists:
+                # Recalculating mod files
+                new_deployment_map = build_deployment_map(staging_metadata)
+                if deployment_map != new_deployment_map:
+                    changes = check_for_deployment_map_change(new_deployment_map, deployment_map)
+                    success = apply_deployment_map_changes(staging_dir, dest_dir, changes, mod_name)
+            else:
+                if unlink_mod_files(staging_mod_dir, dest_dir, mod_files):
+                    for mod_file in mod_files:
+                        del deployment_map[mod_file]
+                    print(f"Successfully removed mod: {mod_name}")
+                else:
+                    success = False
+        
+        # Update deployment map
+        if success and conflicts_exists:
+            deployment_map = new_deployment_map
+        
+        deployment_output = {
+            'success': success,
+            'deployment_map': deployment_map
+        }
+        
+        return deployment_output
 
 # method to get the metadata path that is used everywhere in the app
 def get_metadata_path(base_folder: str, is_staging: bool = True) -> str:
@@ -403,7 +433,6 @@ def load_staging_metadata(path: str) -> dict:
     return data
 
 # Removes the mod from the staging metadata -- metadata allows to list mods that are installed
-# Dashboard.py (l:216)
 def remove_mod_from_metadata(path: str, mod_name: str) -> bool:
     data = load_staging_metadata(path)
 
@@ -420,7 +449,6 @@ def remove_mod_from_metadata(path: str, mod_name: str) -> bool:
     return False
 
 # Writing the metadata with needed fields
-# dashboard.py/create_downloads_page (l:1339)
 def finalise_mod_metadata(filename: str, mod_files: list, deployment_target: dict, staging_meta_path: str, downloads_meta_path: str):
     current_staging_metadata = load_staging_metadata(staging_meta_path)
     current_download_metadata = {}
@@ -461,14 +489,12 @@ def finalise_mod_metadata(filename: str, mod_files: list, deployment_target: dic
         write_yaml(current_staging_metadata, staging_meta_path)
 
 # Mostly returns index, will very likely disappear in the future
-# New
 def read_index(staging_meta_path: str) -> List[str]:
     current_staging_metadata = load_staging_metadata(staging_meta_path)
     return current_staging_metadata["index"]
 
 # Change the mod index from the index list
-# New
-def change_mod_index(staging_meta_path: str, mod_name: str, index: int):
+def change_mod_index(staging_meta_path: str, mod_name: str, index: int) -> dict:
     current_staging_metadata=load_staging_metadata(staging_meta_path)
     
     if mod_name in current_staging_metadata["index"]:
@@ -476,7 +502,6 @@ def change_mod_index(staging_meta_path: str, mod_name: str, index: int):
         mod = current_staging_metadata["index"].pop(pos)
         current_staging_metadata["index"].insert(index, mod)
         
-        return   write_yaml(current_staging_metadata, staging_meta_path) 
-    return False
-
-# Implement a check file method to resync mod metadata if needed
+        write_yaml(current_staging_metadata, staging_meta_path) 
+    
+    return current_staging_metadata

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 from gi.repository import Adw, Gdk, GLib, GObject, Gtk, Gio, GdkPixbuf, Pango
 
-from core.mod_manager import (change_mod_index, check_for_conflicts,
-                              deploy_all_ordered_mods, load_staging_metadata,
-                              read_index, toggle_mod_state)
+from core.mod_manager import (apply_deployment_map_changes, build_deployment_map,
+                              change_mod_index, check_for_conflicts,
+                              check_for_deployment_map_change,
+                              load_staging_metadata, read_index,
+                              toggle_mod_state)
 from core.nexus_api import check_for_mod_updates_async, endorse_nexus_mod
 from core.tools import timestamp_converter, write_yaml, process_bbcode
 from gui.text_window import TextWindow
@@ -26,6 +28,9 @@ class ModsTab(Gtk.Box):
         self.set_margin_top(20)
 
         self.dashboard = dashboard
+
+        # Deployment map is used to redeploy files while moving items
+        self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
 
         # Action bar top right
         action_bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -727,11 +732,14 @@ class ModsTab(Gtk.Box):
                 mod_files=mod_files,
                 state=state,
                 staging_dir=str(self.dashboard.staging_path),
-                deployment_targets=self.dashboard.deployment_targets
+                deployment_targets=self.dashboard.deployment_targets,
+                deployment_map=self.deployment_map
             )
             GLib.idle_add(on_toggle_done, success)
             
         def on_toggle_done(success):
+            if success:
+                self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
             # UI Fallback if toggle fail
             self.dashboard.currently_toggling.discard(mod)
             switch.set_sensitive(True)
@@ -769,7 +777,14 @@ class ModsTab(Gtk.Box):
         if mod_name in current_mods:
             target_index = current_mods.index(mod_name)
             change_mod_index(self.dashboard.staging_metadata_path, value, target_index)
-            deploy_all_ordered_mods(self.dashboard.staging_path, dest_dir)
+            # Redeploy the files that changed
+            new_deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
+            if new_deployment_map != self.deployment_map:
+                changes = check_for_deployment_map_change(new_deployment_map, self.deployment_map)
+                apply_deployment_map_changes(self.dashboard.staging_path, dest_dir, changes, mod_name)
+                self.deployment_map = new_deployment_map
+            
+            # Refresh UI
             self.populate_list()
             return True
         return False

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -30,7 +30,8 @@ class ModsTab(Gtk.Box):
         self.dashboard = dashboard
 
         # Deployment map is used to redeploy files while moving items
-        self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
+        staging_metadata = load_staging_metadata(self.dashboard.staging_metadata_path)
+        self.deployment_map = build_deployment_map(staging_metadata)
 
         # Action bar top right
         action_bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -727,7 +728,7 @@ class ModsTab(Gtk.Box):
             self.deployment_update_btn.set_visible(True)
         
         def worker():
-            success = toggle_mod_state(
+            deployment_output = toggle_mod_state(
                 mod_name=mod,
                 mod_files=mod_files,
                 state=state,
@@ -735,16 +736,16 @@ class ModsTab(Gtk.Box):
                 deployment_targets=self.dashboard.deployment_targets,
                 deployment_map=self.deployment_map
             )
-            GLib.idle_add(on_toggle_done, success)
+            GLib.idle_add(on_toggle_done, deployment_output)
             
-        def on_toggle_done(success):
-            if success:
-                self.deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
+        def on_toggle_done(deployment_output):
+            if deployment_output["success"] == True:
+                self.deployment_map = deployment_output['deployment_map']
             # UI Fallback if toggle fail
             self.dashboard.currently_toggling.discard(mod)
             switch.set_sensitive(True)
-            if state and not success:
-                switch.set_active(False) 
+            if state and not deployment_output['success']:
+                switch.set_active(False)
                 return False
             
             # UI Refresh
@@ -776,9 +777,10 @@ class ModsTab(Gtk.Box):
         
         if mod_name in current_mods:
             target_index = current_mods.index(mod_name)
-            change_mod_index(self.dashboard.staging_metadata_path, value, target_index)
+            new_staging_metadata = change_mod_index(self.dashboard.staging_metadata_path, value, target_index)
+            
             # Redeploy the files that changed
-            new_deployment_map = build_deployment_map(self.dashboard.staging_metadata_path)
+            new_deployment_map = build_deployment_map(new_staging_metadata)
             if new_deployment_map != self.deployment_map:
                 changes = check_for_deployment_map_change(new_deployment_map, self.deployment_map)
                 apply_deployment_map_changes(self.dashboard.staging_path, dest_dir, changes, mod_name)


### PR DESCRIPTION
Changed the whole deployment mod strategy to decrease massively the amount of unlink/relink while replacing a mod when there is a conflict. It means that if you enable a mod that is completely overwritten by other mods, no redeployment will happen. Every change is now calculated and override method on mod deployment should be useless.

Now each mod file is linked to a specific mod in a map built when you're loading the UI. This should be especially impactful for heavy modlists.