### PR TITLE
harmonise utility extraction

### DIFF
--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from gi.repository import GLib
 from core.tools import load_yaml, write_yaml
 from core.user_config import load_user_config
+from core.archive_manager import extract_archive
 
 meta_lock = threading.Lock()
 
@@ -262,47 +263,82 @@ def find_text_file(mod_files: list) -> str:
             return file_path
     return ""
 
-def is_utility_installed(local_zip_path: Path, target_dir: Path) -> bool:
-    if not local_zip_path.exists():
-        return False
-    try:
-        with zipfile.ZipFile(local_zip_path, 'r') as z:
-            return all((target_dir / name).exists() for name in z.namelist() if not name.endswith('/'))
-    except Exception: 
-        return False
-
-def deploy_essential_utility(util_config: dict, downloads_path: str, game_path: str, steam_base: str, steam_id: str):
+def deploy_essential_utility(util_config: dict, downloads_path: str, staging_path: str, game_path: str, steam_base: str, steam_id: str):
     source_url = util_config.get("source")
     filename = source_url.split("/")[-1]
-    zip_path = Path(downloads_path) / "utilities" / filename
+    archive_path = os.path.join(downloads_path, "utilities", filename)
+    staging_path = Path(staging_path) / "utilities" / util_config["name"]
     
     game_root = Path(game_path)
-    install_subpath = util_config.get("utility_path", "")
-    target_dir = game_root / install_subpath
-    target_dir.mkdir(parents=True, exist_ok=True)
 
+    # Archive extraction to staging
+    print("Extracting utility contents")
+    extract_archive(archive_path, staging_path)
+
+    # Whitelist and blacklist management
     whitelist = util_config.get("whitelist", [])
     blacklist = util_config.get("blacklist", [])
-    
-    print("Extracting utility contents")
-    # TODO:Replace function with extract_archive from archive_manager
-    with zipfile.ZipFile(zip_path, 'r') as z:
-        if not whitelist and not blacklist:
-            z.extractall(target_dir)
-        else:
-            for file_info in z.infolist():
-                file_name = file_info.filename
-                if whitelist and not any(allowed in file_name for allowed in whitelist):
-                    continue
-                if blacklist and any(blocked in file_name for blocked in blacklist):
-                    continue
-                z.extract(file_info, target_dir)
 
+    if whitelist or blacklist:
+        print("Applying whitelist/blacklist filters to extracted files...")
+        files_to_remove = []
+
+        for root, dirs, files in os.walk(staging_path):
+            for file_name in files:
+                file_full_path = Path(root) / file_name
+
+                if blacklist and file_name in blacklist:
+                    files_to_remove.append(file_full_path)
+                    continue
+
+                if whitelist and file_name not in whitelist:
+                    files_to_remove.append(file_full_path)
+
+        for file_to_remove in files_to_remove:
+            try:
+                file_to_remove.unlink()
+                print(f"[-] Filtered out: {file_to_remove.name}")
+            except Exception as e:
+                print(f"[!] Failed to remove filtered file {file_to_remove}: {e}")
+
+        # Empty folder cleanup
+        for root, dirs, files in os.walk(staging_path, topdown=False):
+            for dir_name in dirs:
+                dir_full_path = Path(root) / dir_name
+                try:
+                    if not any(dir_full_path.iterdir()):
+                        dir_full_path.rmdir()
+                except Exception:
+                    pass
+
+    # Actual deployment to game files if needed
+    is_internal = util_config.get("install_in_game_files", True)
+    if is_internal:
+        install_subpath = util_config["utility_path"]
+        target_dir = game_root / install_subpath        
+        target_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Deploying utility files to game directory: {target_dir}")
+        for root, dirs, files in os.walk(str(staging_path)):
+            for file_name in files:
+                source_file = os.path.join(root, file_name)
+
+                relative_path = os.path.relpath(source_file, str(staging_path))
+                destination_file = target_dir / relative_path
+                destination_file.parent.mkdir(parents=True, exist_ok=True)
+
+                try:
+                    shutil.copy2(source_file, destination_file)
+                    print(f"[+] Deployed & overwrote: {relative_path}")
+                except Exception as e:
+                    print(f"[!] Failed to copy {relative_path} to game directory: {e}")
+
+    # Some utilities require a command to be launched as a one-shot to enable the utility
     command = util_config.get("enable_command")
     if command:
         print(f"Running utility enable command: {command}")
         subprocess.run(command, shell=True, cwd=game_root)
-    
+
+    # Some utilities require specific launch options to run properly
     steam_launch_options = util_config.get("steam_launch_options")
     if steam_launch_options:
         print(f"Adding Steam launch options: {steam_launch_options}")

--- a/src/core/mod_manager.py
+++ b/src/core/mod_manager.py
@@ -306,10 +306,9 @@ def deploy_essential_utility(util_config: dict, downloads_path: str, staging_pat
             for dir_name in dirs:
                 dir_full_path = Path(root) / dir_name
                 try:
-                    if not any(dir_full_path.iterdir()):
-                        dir_full_path.rmdir()
-                except Exception:
-                    pass
+                    dir_full_path.rmdir()
+                except OSError:
+                    pass # Folder is not empty, so skip it
 
     # Actual deployment to game files if needed
     is_internal = util_config.get("install_in_game_files", True)

--- a/src/gui/dashboard_views/tools_tab.py
+++ b/src/gui/dashboard_views/tools_tab.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from gi.repository import Adw, GLib, Gtk
 
-from core.mod_manager import deploy_essential_utility, is_utility_installed
+from core.mod_manager import deploy_essential_utility
 
 _ = gettext.gettext
 
@@ -67,10 +67,9 @@ class ToolsTab(Gtk.Box):
                 source = util.get("source", "")
                 filename = source.split("/")[-1] if "/" in source else f"{util_id}.zip"
                 util_dir = Path(self.dashboard.downloads_path) / "utilities"
+                staging_dir = Path(self.dashboard.staging_path) / "utilities" / util["name"]
                 local_zip_path = util_dir / filename
                 target_dir = Path(self.dashboard.game_path) / util.get("utility_path", "")
-
-                is_installed = is_utility_installed(local_zip_path, target_dir)
 
                 stack = Gtk.Stack(transition_type=Gtk.StackTransitionType.CROSSFADE)
                 
@@ -100,9 +99,9 @@ class ToolsTab(Gtk.Box):
                 overlay.set_valign(Gtk.Align.CENTER)
                 overlay.set_child(dl_btn)
                 overlay.add_overlay(dl_pbar)
-                
-                inst_btn = Gtk.Button(label=_("Reinstall") if is_installed else "Install", valign=Gtk.Align.CENTER)
-                if not is_installed: 
+
+                inst_btn = Gtk.Button(label=_("Reinstall") if staging_dir.exists() else _("Install"), valign=Gtk.Align.CENTER)
+                if not staging_dir.exists():
                     inst_btn.add_css_class("suggested-action")
                 inst_btn.connect("clicked", self.on_utility_install_clicked, util)
                 
@@ -233,12 +232,10 @@ class ToolsTab(Gtk.Box):
         dialog.present()
 
     def execute_utility_install(self, util):
-        try:
-            deploy_essential_utility(util, self.dashboard.downloads_path, self.dashboard.game_path, self.dashboard.steam_base, self.dashboard.game_config.get("steam_id"))
-            
-            self.dashboard.show_message(
-                _("Success"),
-                _("{} has been installed.").format(util.get('name'))
-            )
-        except Exception as e:
-            self.dashboard.show_message(_("Installation Error"), str(e))
+
+        deploy_essential_utility(util, self.dashboard.downloads_path, self.dashboard.staging_path, self.dashboard.game_path, self.dashboard.steam_base, self.dashboard.game_config.get("steam_id"))
+        
+        self.dashboard.show_message(
+            _("Success"),
+            _("{} has been installed.").format(util.get('name'))
+        )


### PR DESCRIPTION
Utility extraction now uses the same method as mods to extract.
This means that we can now extract utilities that are in 7z or rar format just fine.

Also, a new option was added in the YAML configuration to signal whether a utility should be installed in game directory or simply left in staging: `install_in_game_files` - the default is `True`, meaning that if it is not explicitly set to `False`, the utility will deployed in game files.

## Previous logic
1. User clicks "Download"
2. NOMM downloads utility archive to NOMM downloads folder
3. User clicks "Install"
4. NOMM peeks into contents of zip file to remove potentially non-whitelisted or blacklisted files
5. NOMM then extracts all remaining contents to game directory directly

## New logic
1. User clicks "Download"
2. NOMM downloads utility archive to NOMM downloads folder
3. User clicks "Install"
4. NOMM uses standard archive extraction method to extract entire contents to staging folder (regardless of whether it's zip, 7z or rar)
5. NOMM goes through the extracted files to remove potentially non-whitelisted or blacklisted files
6. IF THE UTILITY IS MARKED AS NEEDING TO BE INSTALLED IN GAME FILES - NOMM copies over contents from the staging folder to the game directory

