### PR TITLE
Add an AUR nightly build allowing users to build from git repo instead of release file + bump previous pkgbuild update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ build/aur/*
 !build/aur/.SRCINFO
 !build/aur/PKGBUILD
 
+build/aur-nightly/*
+!build/aur-nightly/.SRCINFO
+!build/aur-nightly/PKGBUILD
+
 # gtk resources
 resources.gresource

--- a/build/aur-nightly/PKGBUILD
+++ b/build/aur-nightly/PKGBUILD
@@ -1,6 +1,6 @@
-pkgname=nomm
-pkgver=0.11.0
+pkgname=nomm-git
 pkgrel=1
+pkgver=0.11.0.r29.g6efe3f9
 pkgdesc="Native Open Mod Manager - a mod manager for Linux"
 arch=('any')
 url="https://github.com/Allexio/nomm"
@@ -20,11 +20,16 @@ depends=(
 makedepends=(
     'gettext'
 )
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Allexio/nomm/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('4277d8a2290e7e7cf757b65d7740af3128146a7bb204dd8f03de2f12a71aa1ed')
+source=("git+https://github.com/Allexio/nomm.git#branch=main")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "nomm"
+  git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
 
 package() {
-    cd "nomm-$pkgver"
+    cd "nomm"
 
     # App files
     install -dm755 "$pkgdir/usr/lib/nomm"

--- a/build/build.sh
+++ b/build/build.sh
@@ -10,3 +10,8 @@ if [ $1 == "aur" ]; then
     cd "$(dirname "$0")/aur"
     makepkg -si
 fi
+
+if [ $1 == "aur-nightly" ]; then
+    cd "$(dirname "$0")/aur-nightly"
+    makepkg -si
+fi


### PR DESCRIPTION
I added a new pkgbuild to build from the repo instead of depending on releases. I updated the previous pkgbuild with the release sha256 & the new pkgver

pkgbuild for git version implements an automatic versioning, which means all we need to do is change the 0.11.0 into whatever version we're gonna use in the future (and it wouldn't change anything at all with this pkgbuild) and it will automatically change the version with the last commit tag on the next build