### PR TITLE
Add GameBanana links, Switch empty states, bnp support and fix Switch dashboard crash

### DIFF
--- a/build/aur-nightly/.SRCINFO
+++ b/build/aur-nightly/.SRCINFO
@@ -1,11 +1,12 @@
-pkgbase = nomm
+pkgbase = nomm-git
 	pkgdesc = Native Open Mod Manager - a mod manager for Linux
-	pkgver = 0.11.0
+	pkgver = 0.12.1.r21.gcd11ceb
 	pkgrel = 1
 	url = https://github.com/Allexio/nomm
 	arch = any
 	license = GPL3
 	makedepends = gettext
+	makedepends = git
 	depends = python
 	depends = python-gobject
 	depends = gtk4
@@ -16,7 +17,7 @@ pkgbase = nomm
 	depends = unrar
 	depends = python-vdf
 	depends = python-rarfile
-	source = nomm-0.11.0.tar.gz::https://github.com/Allexio/nomm/archive/refs/tags/0.11.0.tar.gz
-	sha256sums = 4277d8a2290e7e7cf757b65d7740af3128146a7bb204dd8f03de2f12a71aa1ed
+	source = git+https://github.com/Allexio/nomm.git#branch=main
+	sha256sums = SKIP
 
-pkgname = nomm
+pkgname = nomm-git

--- a/build/aur-nightly/PKGBUILD
+++ b/build/aur-nightly/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=nomm-git
 pkgrel=1
-pkgver=0.11.0.r29.g6efe3f9
+pkgver=0.12.1.r21.gcd11ceb
 pkgdesc="Native Open Mod Manager - a mod manager for Linux"
 arch=('any')
 url="https://github.com/Allexio/nomm"
@@ -19,6 +19,7 @@ depends=(
 )
 makedepends=(
     'gettext'
+    'git'
 )
 source=("git+https://github.com/Allexio/nomm.git#branch=main")
 sha256sums=('SKIP')
@@ -49,8 +50,8 @@ EOF
         "$pkgdir/usr/share/applications/moe.nomm.Nomm.desktop"
 
     # Icon
-    install -Dm644 assets/nomm.png \
-        "$pkgdir/usr/share/icons/hicolor/64x64/apps/moe.nomm.Nomm.png"
+    install -Dm644 assets/icons/nomm-logo.svg \
+        "$pkgdir/usr/share/icons/hicolor/scalable/apps/moe.nomm.Nomm.svg"
 
     # Localisation
     install -dm755 "$pkgdir/usr/share/locale/fr/LC_MESSAGES"

--- a/build/aur/PKGBUILD
+++ b/build/aur/PKGBUILD
@@ -40,14 +40,14 @@ EOF
     chmod 755 "$pkgdir/usr/bin/nomm"
 
     # Desktop file
-    install -Dm644 build/flatpak/moe.nomm.Nomm.desktop \
-        "$pkgdir/usr/share/applications/moe.nomm.Nomm.desktop"
+    install -Dm644 build/flatpak/com.nomm.Nomm.desktop \
+        "$pkgdir/usr/share/applications/com.nomm.Nomm.desktop"
 
     # Icon
     install -Dm644 assets/nomm.png \
-        "$pkgdir/usr/share/icons/hicolor/64x64/apps/moe.nomm.Nomm.png"
+        "$pkgdir/usr/share/icons/hicolor/64x64/apps/com.nomm.Nomm.png"
 
     # Localisation
     install -dm755 "$pkgdir/usr/share/locale/fr/LC_MESSAGES"
-    msgfmt locale/fr.po -o "$pkgdir/usr/share/locale/fr/LC_MESSAGES/moe.nomm.Nomm.mo"
+    msgfmt locale/fr.po -o "$pkgdir/usr/share/locale/fr/LC_MESSAGES/com.nomm.Nomm.mo"
 }

--- a/src/core/legacy_migration.py
+++ b/src/core/legacy_migration.py
@@ -1,0 +1,378 @@
+import os
+import shutil
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict, Any, Tuple
+
+from core.tools import load_yaml, write_yaml
+from core.mod_manager import load_staging_metadata
+
+# Common files/extensions to ignore during legacy scanning
+IGNORED_FILES = {
+    ".ds_store", "thumbs.db", "desktop.ini", ".git", ".gitignore",
+    ".staging.nomm.yaml", ".downloads.nomm.yaml"
+}
+
+IGNORED_EXTENSIONS = {
+    ".tmp", ".bak", ".log", ".txt", ".md"
+}
+
+# Base game pak patterns in Unreal Engine (when scanning Content/Paks directly)
+BASE_PAK_PREFIXES = (
+    "pakchunk0", "pakchunk1", "global"
+)
+
+# Known mod subdirectories relative to game_path when mods_path is "" or game root
+KNOWN_GAME_MOD_DIRS = [
+    # Cyberpunk 2077
+    ("archive/pc/mod", "flat"),
+    ("bin/x64/plugins/cyber_engine_tweaks/mods", "folders"),
+    ("r6/scripts", "tree"),
+    ("r6/tweaks", "tree"),
+    ("red4ext/plugins", "folders"),
+    ("mods", "tree"),
+    ("Mods", "tree"),
+    # RE Engine (Resident Evil, Monster Hunter)
+    ("natives", "tree"),
+    ("reframework/autorun", "flat"),
+    ("reframework/plugins", "flat"),
+    # Unity / BepInEx
+    ("BepInEx/plugins", "tree"),
+    ("BepInEx/patchers", "tree"),
+    # Unreal Engine
+    ("Content/Paks/~mods", "flat"),
+]
+
+
+def scan_legacy_mods(game_info: dict, staging_path: Path | str) -> List[Dict[str, Any]]:
+    """
+    Scans the game directory for unmanaged (non-symlink) legacy mod files.
+    Returns a list of detected mod definitions ready for migration.
+    """
+    game_path = Path(game_info["path"])
+    staging_path = Path(staging_path)
+    staging_meta_path = staging_path / ".staging.nomm.yaml"
+    staging_metadata = load_staging_metadata(str(staging_meta_path))
+
+    existing_mod_names = set(staging_metadata.get("mods", {}).keys())
+
+    # Build set of already-managed relative file paths
+    managed_rel_files = set()
+    for mod_data in staging_metadata.get("mods", {}).values():
+        for f in mod_data.get("mod_files", []):
+            managed_rel_files.add(os.path.normpath(f))
+
+    deployment_targets = game_info.get("mod_paths", [])
+    if not deployment_targets:
+        deployment_targets = [{"name": "default", "path": str(game_path)}]
+
+    detected_mods = []
+    processed_sources = set()
+    scanned_directories = set()
+
+    # 1. Inspect explicit deployment targets (e.g. BepInEx/plugins, Content/Paks/~mods, mods/)
+    for target in deployment_targets:
+        target_path_str = target.get("path")
+        if not target_path_str:
+            continue
+        target_path = Path(target_path_str)
+        if not target_path.exists():
+            continue
+
+        resolved_target = str(target_path.resolve())
+        # If deployment target is a dedicated mod folder (not the game root)
+        if target_path.resolve() != game_path.resolve():
+            scanned_directories.add(resolved_target)
+            _scan_directory(
+                target_path,
+                deployment_base=target_path,
+                game_path=game_path,
+                managed_rel_files=managed_rel_files,
+                processed_sources=processed_sources,
+                detected_mods=detected_mods,
+                existing_mod_names=existing_mod_names,
+                scan_mode="tree"
+            )
+
+    # 2. Inspect known mod subdirectories under game_path
+    for rel_dir, scan_mode in KNOWN_GAME_MOD_DIRS:
+        full_dir = game_path / rel_dir
+        resolved_full_dir = str(full_dir.resolve())
+        if full_dir.exists() and full_dir.is_dir() and resolved_full_dir not in scanned_directories:
+            scanned_directories.add(resolved_full_dir)
+            _scan_directory(
+                full_dir,
+                deployment_base=game_path,
+                game_path=game_path,
+                managed_rel_files=managed_rel_files,
+                processed_sources=processed_sources,
+                detected_mods=detected_mods,
+                existing_mod_names=existing_mod_names,
+                scan_mode=scan_mode
+            )
+
+    return detected_mods
+
+
+def _scan_directory(
+    directory: Path,
+    deployment_base: Path,
+    game_path: Path,
+    managed_rel_files: set,
+    processed_sources: set,
+    detected_mods: list,
+    existing_mod_names: set,
+    scan_mode: str = "tree"
+):
+    """
+    Helper to scan a specific directory for unmanaged non-symlink mod files/folders.
+    """
+    if not directory.exists() or not directory.is_dir():
+        return
+
+    # Mode 1: Flat folder (e.g. archive/pc/mod, Content/Paks/~mods)
+    # Group files sharing the same stem into one mod
+    if scan_mode == "flat":
+        stem_groups: Dict[str, list] = {}
+        for entry in os.scandir(directory):
+            if entry.is_symlink():
+                continue
+            if not entry.is_file():
+                continue
+            if entry.name.lower() in IGNORED_FILES or entry.name.startswith("."):
+                continue
+            if any(entry.name.lower().endswith(ext) for ext in IGNORED_EXTENSIONS):
+                continue
+            if any(entry.name.lower().startswith(p) for p in BASE_PAK_PREFIXES):
+                continue
+
+            file_path = Path(entry.path)
+            if str(file_path.resolve()) in processed_sources:
+                continue
+
+            rel_to_deploy = os.path.normpath(file_path.relative_to(deployment_base))
+            if rel_to_deploy in managed_rel_files:
+                continue
+
+            # Group by file stem (e.g. MyMod.archive + MyMod.xl -> "MyMod")
+            stem = file_path.stem
+            stem_groups.setdefault(stem, []).append({
+                "source": file_path,
+                "rel_path": rel_to_deploy
+            })
+            processed_sources.add(str(file_path.resolve()))
+
+        for stem, file_entries in stem_groups.items():
+            mod_name = _get_unique_mod_name(stem, existing_mod_names, [m["name"] for m in detected_mods])
+            detected_mods.append({
+                "name": mod_name,
+                "folder_name": mod_name,
+                "deployment_path": str(deployment_base),
+                "files": file_entries,
+                "category": "flat_files"
+            })
+
+    # Mode 2: Folder-based mod directory (e.g. CET mods, red4ext plugins, Witcher 3 mods/)
+    elif scan_mode == "folders":
+        for entry in os.scandir(directory):
+            if entry.is_symlink():
+                continue
+            if not entry.is_dir():
+                continue
+            if entry.name.startswith("."):
+                continue
+
+            folder_path = Path(entry.path)
+            if str(folder_path.resolve()) in processed_sources:
+                continue
+
+            file_entries = []
+            for root, _, files in os.walk(folder_path):
+                for f in files:
+                    fp = Path(root) / f
+                    if fp.is_symlink():
+                        continue
+                    if f.lower() in IGNORED_FILES or f.startswith("."):
+                        continue
+                    rel_to_deploy = os.path.normpath(fp.relative_to(deployment_base))
+                    if rel_to_deploy in managed_rel_files:
+                        continue
+                    file_entries.append({
+                        "source": fp,
+                        "rel_path": rel_to_deploy
+                    })
+                    processed_sources.add(str(fp.resolve()))
+
+            if file_entries:
+                mod_name = _get_unique_mod_name(folder_path.name, existing_mod_names, [m["name"] for m in detected_mods])
+                detected_mods.append({
+                    "name": mod_name,
+                    "folder_name": mod_name,
+                    "deployment_path": str(deployment_base),
+                    "files": file_entries,
+                    "category": "folder"
+                })
+
+    # Mode 3: General tree (handles both loose files and subfolders)
+    elif scan_mode == "tree":
+        stem_groups: Dict[str, list] = {}
+        for entry in os.scandir(directory):
+            if entry.is_symlink():
+                continue
+            if entry.name.lower() in IGNORED_FILES or entry.name.startswith("."):
+                continue
+
+            if entry.is_dir():
+                folder_path = Path(entry.path)
+                if str(folder_path.resolve()) in processed_sources:
+                    continue
+
+                file_entries = []
+                for root, _, files in os.walk(folder_path):
+                    for f in files:
+                        fp = Path(root) / f
+                        if fp.is_symlink():
+                            continue
+                        if f.lower() in IGNORED_FILES or f.startswith("."):
+                            continue
+                        rel_to_deploy = os.path.normpath(fp.relative_to(deployment_base))
+                        if rel_to_deploy in managed_rel_files:
+                            continue
+                        file_entries.append({
+                            "source": fp,
+                            "rel_path": rel_to_deploy
+                        })
+                        processed_sources.add(str(fp.resolve()))
+
+                if file_entries:
+                    processed_sources.add(str(folder_path.resolve()))
+                    mod_name = _get_unique_mod_name(folder_path.name, existing_mod_names, [m["name"] for m in detected_mods])
+                    detected_mods.append({
+                        "name": mod_name,
+                        "folder_name": mod_name,
+                        "deployment_path": str(deployment_base),
+                        "files": file_entries,
+                        "category": "folder"
+                    })
+            elif entry.is_file():
+                if any(entry.name.lower().endswith(ext) for ext in IGNORED_EXTENSIONS):
+                    continue
+                if any(entry.name.lower().startswith(p) for p in BASE_PAK_PREFIXES):
+                    continue
+
+                file_path = Path(entry.path)
+                if str(file_path.resolve()) in processed_sources:
+                    continue
+
+                rel_to_deploy = os.path.normpath(file_path.relative_to(deployment_base))
+                if rel_to_deploy in managed_rel_files:
+                    continue
+
+                stem = file_path.stem
+                stem_groups.setdefault(stem, []).append({
+                    "source": file_path,
+                    "rel_path": rel_to_deploy
+                })
+                processed_sources.add(str(file_path.resolve()))
+
+        for stem, file_entries in stem_groups.items():
+            mod_name = _get_unique_mod_name(stem, existing_mod_names, [m["name"] for m in detected_mods])
+            detected_mods.append({
+                "name": mod_name,
+                "folder_name": mod_name,
+                "deployment_path": str(deployment_base),
+                "files": file_entries,
+                "category": "flat_files"
+            })
+
+
+def _get_unique_mod_name(base_name: str, existing_names: set, current_detected_names: list) -> str:
+    """Returns a unique mod name avoiding collisions with existing or newly detected mods."""
+    sanitized = base_name.strip()
+    if not sanitized:
+        sanitized = "unnamed_mod"
+
+    candidate = sanitized
+    counter = 1
+    taken = existing_names.union(set(current_detected_names))
+    while candidate in taken:
+        candidate = f"{sanitized}_{counter}"
+        counter += 1
+    return candidate
+
+
+def migrate_legacy_mods(
+    game_info: dict,
+    staging_path: Path | str,
+    staging_metadata_path: Path | str,
+    legacy_mods: List[Dict[str, Any]]
+) -> Tuple[int, List[str]]:
+    """
+    Migrates the detected legacy mods to NOMM's staging directory and creates symlinks.
+    Returns (success_count, error_messages).
+    """
+    staging_path = Path(staging_path)
+    staging_meta_path = Path(staging_metadata_path)
+    staging_metadata = load_staging_metadata(str(staging_meta_path))
+
+    success_count = 0
+    errors = []
+
+    for mod in legacy_mods:
+        mod_name = mod["name"]
+        folder_name = mod["folder_name"]
+        deployment_path = Path(mod["deployment_path"])
+        files = mod["files"]
+
+        staging_mod_dir = staging_path / folder_name
+        migrated_rel_files = []
+        mod_failed = False
+
+        for file_entry in files:
+            source_file = Path(file_entry["source"])
+            rel_path = file_entry["rel_path"]
+            dest_staging_file = staging_mod_dir / rel_path
+
+            if not source_file.exists() and not source_file.is_symlink():
+                continue
+
+            try:
+                # 1. Create parent folders in staging
+                dest_staging_file.parent.mkdir(parents=True, exist_ok=True)
+
+                # 2. Move the real file into staging
+                # Note: shutil.move works across different filesystems / mounts
+                shutil.move(str(source_file), str(dest_staging_file))
+
+                # 3. Create symlink in place of original file
+                source_file.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(dest_staging_file, source_file)
+
+                migrated_rel_files.append(rel_path)
+                print(f"[+] Migrated legacy mod file: {source_file} -> {dest_staging_file}")
+            except Exception as e:
+                err_msg = f"Failed to migrate {source_file}: {e}"
+                print(f"[!] {err_msg}")
+                errors.append(err_msg)
+                mod_failed = True
+
+        if migrated_rel_files and not mod_failed:
+            now = datetime.now()
+            staging_metadata["mods"][mod_name] = {
+                "folder_name": folder_name,
+                "display_name": mod_name,
+                "mod_files": migrated_rel_files,
+                "deployment_path": str(deployment_path),
+                "install_timestamp": now,
+                "enabled_timestamp": now,
+                "is_migrated": True
+            }
+            if mod_name not in staging_metadata["index"]:
+                staging_metadata["index"].append(mod_name)
+
+            success_count += 1
+
+    # Save updated metadata
+    write_yaml(staging_metadata, str(staging_meta_path))
+
+    return success_count, errors

--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -187,20 +187,31 @@ def sanitize_for_pango(raw_html: str) -> str:
 def list_archives(archives_directory: str):
 
     ARCHIVE_MIME_TYPES = {
-                "application/zip",
-                "application/x-zip-compressed",
-                "application/x-rar",
-                "application/vnd.rar",
-                "application/x-rar-compressed",
-                "application/x-7z-compressed"
-            }
+        "application/zip",
+        "application/x-zip-compressed",
+        "application/x-rar",
+        "application/vnd.rar",
+        "application/x-rar-compressed",
+        "application/x-7z-compressed",
+        "application/x-tar",
+        "application/gzip"
+    }
+
+    ARCHIVE_EXTENSIONS = (
+        ".zip", ".rar", ".7z", ".tar", ".gz", ".xz", ".tgz", ".bnp"
+    )
 
     archive_list = []
 
     for file in os.listdir(archives_directory):
         full_path = os.path.join(archives_directory, file)
         
-        if not os.path.isfile(full_path):
+        if not os.path.isfile(full_path) or file.startswith("."):
+            continue
+
+        # Check by known file extension first
+        if any(file.lower().endswith(ext) for ext in ARCHIVE_EXTENSIONS):
+            archive_list.append(file)
             continue
             
         try:
@@ -208,13 +219,12 @@ def list_archives(archives_directory: str):
             file_info = gio_file.query_info("standard::content-type", Gio.FileQueryInfoFlags.NONE, None)
             mime_type = file_info.get_content_type()
             
-            
             # If the OS identifies it as a known archive file type, pull it in
             if mime_type in ARCHIVE_MIME_TYPES:
                 archive_list.append(file)
             else:
                 if "yaml" not in mime_type:
-                    print(f"[!] Could not identify mime type in download folder: {mime_type}")
+                    print(f"[!] Could not identify mime type in download folder: {mime_type} ({file})")
         except Exception as e:
             print(f"Error reading file metadata for {file}: {e}")
     

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -281,10 +281,16 @@ class Nomm(Adw.Application):
         dialog.select_folder(self.win, None, self.on_downloads_folder_selected_callback)
 
     def on_downloads_folder_selected_callback(self, dialog, result):
-        selected_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
-        self.temp_config = {"download_path": selected_folder_path, "library_paths": []}
-        self.user_defined_paths = [selected_folder_path]
-        self.show_staging_select_screen()
+        try:
+            folder = dialog.select_folder_finish(result)
+            if not folder:
+                return
+            selected_folder_path = translate_fuse_path(folder)
+            self.temp_config = {"download_path": selected_folder_path, "library_paths": []}
+            self.user_defined_paths = [selected_folder_path]
+            self.show_staging_select_screen()
+        except Exception as e:
+            print(f"Mod downloads folder selection cancelled or failed: {e}")
 
     def show_staging_select_screen(self):
         self.remove_stack_child("setup")
@@ -311,10 +317,16 @@ class Nomm(Adw.Application):
         dialog.select_folder(self.win, None, self.on_staging_folder_selected_callback)
 
     def on_staging_folder_selected_callback(self, dialog, result):
-        selected_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
-        self.temp_config["staging_path"] = selected_folder_path
-        self.user_defined_paths.append(selected_folder_path)
-        self.show_nexus_api_key_screen()
+        try:
+            folder = dialog.select_folder_finish(result)
+            if not folder:
+                return
+            selected_folder_path = translate_fuse_path(folder)
+            self.temp_config["staging_path"] = selected_folder_path
+            self.user_defined_paths.append(selected_folder_path)
+            self.show_nexus_api_key_screen()
+        except Exception as e:
+            print(f"Mod staging folder selection cancelled or failed: {e}")
 
     def show_nexus_api_key_screen(self):
         self.remove_stack_child("api_key")
@@ -427,16 +439,24 @@ class Nomm(Adw.Application):
         self.stack.set_visible_child_name("preferred_emu")
 
     def steam_user_id_handler(self):
-        steam_userdata_path = self.steam_base + "userdata/"
+        if not self.steam_base:
+            self.finalize_setup()
+            return
+        steam_userdata_path = os.path.join(self.steam_base, "userdata")
+        if not os.path.isdir(steam_userdata_path):
+            self.finalize_setup()
+            return
         steam_user_ids = [f for f in os.listdir(steam_userdata_path) if os.path.isdir(os.path.join(steam_userdata_path, f))]
         if "0" in steam_user_ids:
             steam_user_ids.remove("0")
         print(f"Steam user IDs detected: {steam_user_ids}")
         if len(steam_user_ids) > 1:
             self.show_steam_user_id_selection_screen(steam_user_ids)
-        else:
+        elif len(steam_user_ids) == 1:
             steam_user_id = steam_user_ids[0]
             self.temp_config["steam_user_id"] = steam_user_id
+            self.finalize_setup()
+        else:
             self.finalize_setup()
 
     def show_steam_user_id_selection_screen(self, steam_user_ids):

--- a/src/gui/dashboard.py
+++ b/src/gui/dashboard.py
@@ -30,7 +30,14 @@ class GameDashboard(Gtk.Box):
         self.game_path = game_info["path"]
         self.platform = game_info["platform"]
         self.app_id = game_info.get("app_id")
-        self.game_config = load_yaml(game_info["game_config_path"])
+        raw_config = load_yaml(game_info["game_config_path"])
+        if isinstance(raw_config, list):
+            self.game_config = next(
+                (g for g in raw_config if g.get("full_name") == self.game_name or str(g.get("switch_id", "")).lower() == str(self.app_id).lower()),
+                {"name": self.game_name, "switch_id": self.app_id}
+            )
+        else:
+            self.game_config = raw_config or {}
         user_config = load_yaml(application.user_config_path)
         self.downloads_path = str(Path(os.path.join(Path(user_config.get("download_path")), self.game_name)))
         self.staging_path = Path(os.path.join(Path(user_config.get("staging_path")), self.game_name))

--- a/src/gui/dashboard.py
+++ b/src/gui/dashboard.py
@@ -25,6 +25,7 @@ class GameDashboard(Gtk.Box):
     def __init__(self, application, game_info, **kwargs):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, **kwargs)
         self.app = application
+        self.game_info = game_info
         self.game_name = game_info["name"]
         self.game_path = game_info["path"]
         self.platform = game_info["platform"]

--- a/src/gui/dashboard_views/downloads_tab.py
+++ b/src/gui/dashboard_views/downloads_tab.py
@@ -57,7 +57,16 @@ class DownloadsTab(Gtk.Box):
         spacer = Gtk.Box(hexpand=True)
         action_bar.append(spacer)
 
-        if "nexus_id" in self.dashboard.game_config:
+        if self.dashboard.platform == "switch":
+            from urllib.parse import quote
+            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(self.dashboard.game_name)}"
+            gb_btn = create_icon_button(
+                icon_name="gamebanana-logo",
+                tooltip=_(f"Browse GameBanana mods for {self.dashboard.game_name}"),
+                on_click=lambda x: webbrowser.open(gb_url)
+            )
+            action_bar.append(gb_btn)
+        elif "nexus_id" in self.dashboard.game_config:
             nexus_id = self.dashboard.game_config["nexus_id"]
             nexus_btn = create_icon_button(
                 icon_name="nexus-logo",
@@ -74,7 +83,6 @@ class DownloadsTab(Gtk.Box):
         )
         action_bar.append(folder_btn)
         
-        
         self.append(action_bar)
 
         # Downloads
@@ -88,17 +96,28 @@ class DownloadsTab(Gtk.Box):
         self.append(self.scrolled)
 
         # Empty State
+        is_switch = (self.dashboard.platform == "switch")
         self.empty_state = Adw.StatusPage(
             icon_name="folder-download-symbolic",
             title=_("No Downloads Found"),
-            description=_("Drag and drop mod archives (.zip, .7z, .rar) into this window,\nor download them directly from Nexus Mods using 'Mod Manager Download'."),
+            description=_("Drag and drop Switch mod archives (.zip, .7z, .rar) into this window,\nor download them directly from GameBanana.") if is_switch else _("Drag and drop mod archives (.zip, .7z, .rar) into this window,\nor download them directly from Nexus Mods using 'Mod Manager Download'."),
             vexpand=True,
             hexpand=True
         )
 
         dl_empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
 
-        if "nexus_id" in self.dashboard.game_config:
+        if is_switch:
+            from urllib.parse import quote
+            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(self.dashboard.game_name)}"
+            browse_gb_btn = Gtk.Button()
+            browse_gb_btn.set_child(Adw.ButtonContent(icon_name="gamebanana-logo", label=_("Browse GameBanana")))
+            browse_gb_btn.add_css_class("suggested-action")
+            browse_gb_btn.add_css_class("pill")
+            browse_gb_btn.set_cursor_from_name("pointer")
+            browse_gb_btn.connect("clicked", lambda x: webbrowser.open(gb_url))
+            dl_empty_buttons.append(browse_gb_btn)
+        elif "nexus_id" in self.dashboard.game_config:
             nexus_id = self.dashboard.game_config["nexus_id"]
             browse_nexus_btn = Gtk.Button()
             browse_nexus_btn.set_child(Adw.ButtonContent(icon_name="nexus-logo", label=_("Browse Nexus Mods")))

--- a/src/gui/dashboard_views/downloads_tab.py
+++ b/src/gui/dashboard_views/downloads_tab.py
@@ -54,13 +54,24 @@ class DownloadsTab(Gtk.Box):
         
         action_bar.append(filter_group)
         
+        spacer = Gtk.Box(hexpand=True)
+        action_bar.append(spacer)
+
+        if "nexus_id" in self.dashboard.game_config:
+            nexus_id = self.dashboard.game_config["nexus_id"]
+            nexus_btn = create_icon_button(
+                icon_name="nexus-logo",
+                tooltip=_("Open Nexus Mods page"),
+                on_click=lambda x: webbrowser.open(f"https://www.nexusmods.com/{nexus_id}/mods/")
+            )
+            action_bar.append(nexus_btn)
+
         # Folder button
         folder_btn = create_icon_button(
             icon_name="mat-folder-symbolic",
             tooltip=_("Open downloads folder"),
             on_click=lambda x: webbrowser.open(f"file://{self.dashboard.downloads_path}")
         )
-        folder_btn.set_hexpand(True)
         action_bar.append(folder_btn)
         
         
@@ -75,6 +86,38 @@ class DownloadsTab(Gtk.Box):
         self.scrolled = Gtk.ScrolledWindow(vexpand=True)
         self.scrolled.set_child(self.list_box)
         self.append(self.scrolled)
+
+        # Empty State
+        self.empty_state = Adw.StatusPage(
+            icon_name="folder-download-symbolic",
+            title=_("No Downloads Found"),
+            description=_("Drag and drop mod archives (.zip, .7z, .rar) into this window,\nor download them directly from Nexus Mods using 'Mod Manager Download'."),
+            vexpand=True,
+            hexpand=True
+        )
+
+        dl_empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
+
+        if "nexus_id" in self.dashboard.game_config:
+            nexus_id = self.dashboard.game_config["nexus_id"]
+            browse_nexus_btn = Gtk.Button()
+            browse_nexus_btn.set_child(Adw.ButtonContent(icon_name="nexus-logo", label=_("Browse Nexus Mods")))
+            browse_nexus_btn.add_css_class("suggested-action")
+            browse_nexus_btn.add_css_class("pill")
+            browse_nexus_btn.set_cursor_from_name("pointer")
+            browse_nexus_btn.connect("clicked", lambda x: webbrowser.open(f"https://www.nexusmods.com/{nexus_id}/mods/"))
+            dl_empty_buttons.append(browse_nexus_btn)
+
+        open_folder_btn = Gtk.Button()
+        open_folder_btn.set_child(Adw.ButtonContent(icon_name="mat-folder-symbolic", label=_("Open Downloads Folder")))
+        open_folder_btn.add_css_class("pill")
+        open_folder_btn.set_cursor_from_name("pointer")
+        open_folder_btn.connect("clicked", lambda x: webbrowser.open(f"file://{self.dashboard.downloads_path}"))
+        dl_empty_buttons.append(open_folder_btn)
+
+        self.empty_state.set_child(dl_empty_buttons)
+        self.append(self.empty_state)
+        self.empty_state.set_visible(False)
         
         # Drag and drop files into the download box
         drop_target = Gtk.DropTarget.new(Gdk.FileList, Gdk.DragAction.COPY)
@@ -114,6 +157,14 @@ class DownloadsTab(Gtk.Box):
 
             while child := self.list_box.get_first_child():
                 self.list_box.remove(child)
+
+            if not files:
+                self.scrolled.set_visible(False)
+                self.empty_state.set_visible(True)
+                return
+            else:
+                self.empty_state.set_visible(False)
+                self.scrolled.set_visible(True)
 
             install_btn_sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
             version_badge_sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)

--- a/src/gui/dashboard_views/downloads_tab.py
+++ b/src/gui/dashboard_views/downloads_tab.py
@@ -58,8 +58,8 @@ class DownloadsTab(Gtk.Box):
         action_bar.append(spacer)
 
         if self.dashboard.platform == "switch":
-            from urllib.parse import quote
-            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(self.dashboard.game_name)}"
+            from urllib.parse import quote_plus
+            gb_url = f"https://gamebanana.com/search?_sModelName=Game&_sOrder=best_match&_sSearchString={quote_plus(self.dashboard.game_name)}"
             gb_btn = create_icon_button(
                 icon_name="gamebanana-logo",
                 tooltip=_(f"Browse GameBanana mods for {self.dashboard.game_name}"),
@@ -108,8 +108,8 @@ class DownloadsTab(Gtk.Box):
         dl_empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
 
         if is_switch:
-            from urllib.parse import quote
-            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(self.dashboard.game_name)}"
+            from urllib.parse import quote_plus
+            gb_url = f"https://gamebanana.com/search?_sModelName=Game&_sOrder=best_match&_sSearchString={quote_plus(self.dashboard.game_name)}"
             browse_gb_btn = Gtk.Button()
             browse_gb_btn.set_child(Adw.ButtonContent(icon_name="gamebanana-logo", label=_("Browse GameBanana")))
             browse_gb_btn.add_css_class("suggested-action")

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -61,7 +61,16 @@ class ModsTab(Gtk.Box):
         spacer = Gtk.Box(hexpand=True)
         action_bar.append(spacer)
 
-        if "nexus_id" in dashboard.game_config:
+        if dashboard.platform == "switch":
+            from urllib.parse import quote
+            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(dashboard.game_name)}"
+            gb_btn = create_icon_button(
+                icon_name="gamebanana-logo",
+                tooltip=_(f"Browse GameBanana mods for {dashboard.game_name}"),
+                on_click=lambda x: webbrowser.open(gb_url)
+            )
+            action_bar.append(gb_btn)
+        elif "nexus_id" in dashboard.game_config:
             nexus_id = dashboard.game_config["nexus_id"]
             nexus_btn = create_icon_button(
                 icon_name="nexus-logo",
@@ -129,17 +138,28 @@ class ModsTab(Gtk.Box):
         self.main_content.append(self.revealer)
 
         # Empty State
+        is_switch = (dashboard.platform == "switch")
         self.empty_state = Adw.StatusPage(
-            icon_name="nexus-logo" if "nexus_id" in dashboard.game_config else "nomm-logo",
-            title=_("No Mods Installed Yet"),
-            description=_("You haven't installed any mods for this game yet.\nBrowse Nexus Mods to download mods with 'Mod Manager Download', or install downloaded archives from the Downloads tab."),
+            icon_name="gamebanana-logo" if is_switch else ("nexus-logo" if "nexus_id" in dashboard.game_config else "nomm-logo"),
+            title=_("No Switch Mods Installed Yet") if is_switch else _("No Mods Installed Yet"),
+            description=_("Switch mods typically come from GameBanana as archives (.zip, .rar, .7z) containing 'romfs' or 'exefs' folders.\nBrowse GameBanana to download mods, or drag mod archives into the Downloads tab.") if is_switch else _("You haven't installed any mods for this game yet.\nBrowse Nexus Mods to download mods with 'Mod Manager Download', or install downloaded archives from the Downloads tab."),
             vexpand=True,
             hexpand=True
         )
         
         empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
         
-        if "nexus_id" in dashboard.game_config:
+        if is_switch:
+            from urllib.parse import quote
+            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(dashboard.game_name)}"
+            browse_gb_btn = Gtk.Button()
+            browse_gb_btn.set_child(Adw.ButtonContent(icon_name="gamebanana-logo", label=_("Browse GameBanana")))
+            browse_gb_btn.add_css_class("suggested-action")
+            browse_gb_btn.add_css_class("pill")
+            browse_gb_btn.set_cursor_from_name("pointer")
+            browse_gb_btn.connect("clicked", lambda x: webbrowser.open(gb_url))
+            empty_buttons.append(browse_gb_btn)
+        elif "nexus_id" in dashboard.game_config:
             nexus_id = dashboard.game_config["nexus_id"]
             browse_nexus_btn = Gtk.Button()
             browse_nexus_btn.set_child(Adw.ButtonContent(icon_name="nexus-logo", label=_("Browse Nexus Mods")))
@@ -1138,17 +1158,19 @@ class ModsTab(Gtk.Box):
         threading.Thread(target=worker, daemon=True).start()
 
     def update_empty_state_with_legacy(self, legacy_count: int):
+        is_switch = (self.dashboard.platform == "switch")
         if legacy_count > 0:
             self.empty_state.set_title(_("Unmanaged Mods Detected"))
             self.empty_state.set_description(
-                _("Found {} unmanaged legacy mod(s) in the game directory.\n"
+                _("Found {} unmanaged legacy mod(s) in the game/emulator directory.\n"
                   "Click 'Migrate Existing Mods' below to import them into NOMM.").format(legacy_count)
             )
             self.empty_migrate_btn.add_css_class("suggested-action")
             self.empty_migrate_btn.set_visible(True)
         else:
-            self.empty_state.set_title(_("No Mods Installed Yet"))
+            self.empty_state.set_title(_("No Switch Mods Installed Yet") if is_switch else _("No Mods Installed Yet"))
             self.empty_state.set_description(
+                _("Switch mods typically come from GameBanana as archives (.zip, .rar, .7z) containing 'romfs' or 'exefs' folders.\nBrowse GameBanana to download mods, or drag mod archives into the Downloads tab.") if is_switch else
                 _("You haven't installed any mods for this game yet.\n"
                   "Browse Nexus Mods to download mods with 'Mod Manager Download', or install downloaded archives from the Downloads tab.")
             )

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -62,8 +62,8 @@ class ModsTab(Gtk.Box):
         action_bar.append(spacer)
 
         if dashboard.platform == "switch":
-            from urllib.parse import quote
-            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(dashboard.game_name)}"
+            from urllib.parse import quote_plus
+            gb_url = f"https://gamebanana.com/search?_sModelName=Game&_sOrder=best_match&_sSearchString={quote_plus(dashboard.game_name)}"
             gb_btn = create_icon_button(
                 icon_name="gamebanana-logo",
                 tooltip=_(f"Browse GameBanana mods for {dashboard.game_name}"),
@@ -150,8 +150,8 @@ class ModsTab(Gtk.Box):
         empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
         
         if is_switch:
-            from urllib.parse import quote
-            gb_url = f"https://gamebanana.com/games/search?_sSearchString={quote(dashboard.game_name)}"
+            from urllib.parse import quote_plus
+            gb_url = f"https://gamebanana.com/search?_sModelName=Game&_sOrder=best_match&_sSearchString={quote_plus(dashboard.game_name)}"
             browse_gb_btn = Gtk.Button()
             browse_gb_btn.set_child(Adw.ButtonContent(icon_name="gamebanana-logo", label=_("Browse GameBanana")))
             browse_gb_btn.add_css_class("suggested-action")

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -16,6 +16,7 @@ from platforms.nexus import get_nexus_changelog, endorse_nexus_mod
 from platforms.nexus import get_mod_info as get_nexus_mod_info
 from platforms.gamebanana import get_mod_info as get_gamebanana_mod_info
 from core.tools import timestamp_converter, write_yaml, create_icon_button
+from core.legacy_migration import scan_legacy_mods, migrate_legacy_mods
 from gui.text_window import TextWindow
 from typing import Optional, Callable
 
@@ -88,6 +89,13 @@ class ModsTab(Gtk.Box):
             on_click=self.check_for_updates
         )
 
+        migrate_btn = create_icon_button(
+            icon_name="mat-folder-managed-symbolic",
+            tooltip=_("Scan & migrate legacy / unmanaged mods from game folder"),
+            on_click=self.on_scan_and_migrate_legacy_mods
+        )
+        action_bar.append(migrate_btn)
+
         action_bar.append(folder_btn)
         action_bar.append(update_btn)
 
@@ -147,6 +155,13 @@ class ModsTab(Gtk.Box):
         downloads_btn.set_cursor_from_name("pointer")
         downloads_btn.connect("clicked", lambda x: self.dashboard.dl_tab_btn.set_active(True))
         empty_buttons.append(downloads_btn)
+
+        self.empty_migrate_btn = Gtk.Button()
+        self.empty_migrate_btn.set_child(Adw.ButtonContent(icon_name="mat-folder-managed-symbolic", label=_("Migrate Existing Mods")))
+        self.empty_migrate_btn.add_css_class("pill")
+        self.empty_migrate_btn.set_cursor_from_name("pointer")
+        self.empty_migrate_btn.connect("clicked", self.on_scan_and_migrate_legacy_mods)
+        empty_buttons.append(self.empty_migrate_btn)
 
         if "wiki_link" in dashboard.game_config:
             wiki_guide_btn = Gtk.Button()
@@ -790,6 +805,10 @@ class ModsTab(Gtk.Box):
             if not staging_metadata or not staging_metadata.get("mods"):
                 self.main_content.set_visible(False)
                 self.empty_state.set_visible(True)
+                def check_empty_legacy():
+                    legacy = scan_legacy_mods(self.dashboard.game_info, staging_path)
+                    GLib.idle_add(self.update_empty_state_with_legacy, len(legacy))
+                threading.Thread(target=check_empty_legacy, daemon=True).start()
                 return
             else:
                 self.empty_state.set_visible(False)
@@ -819,7 +838,8 @@ class ModsTab(Gtk.Box):
                 row.set_activatable(True)
                 row.mod_data = mod_metadata
                 row.mod_data_index = mod
-                row.set_subtitle(mod_metadata.get("author", ""))
+                subtitle = mod_metadata.get("author") or (_("Migrated Legacy Mod") if mod_metadata.get("is_migrated") else "")
+                row.set_subtitle(subtitle)
 
                 row_element_margin = 10
 
@@ -1116,3 +1136,91 @@ class ModsTab(Gtk.Box):
             GLib.idle_add(on_complete_callback, staging_metadata)
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def update_empty_state_with_legacy(self, legacy_count: int):
+        if legacy_count > 0:
+            self.empty_state.set_title(_("Unmanaged Mods Detected"))
+            self.empty_state.set_description(
+                _("Found {} unmanaged legacy mod(s) in the game directory.\n"
+                  "Click 'Migrate Existing Mods' below to import them into NOMM.").format(legacy_count)
+            )
+            self.empty_migrate_btn.add_css_class("suggested-action")
+            self.empty_migrate_btn.set_visible(True)
+        else:
+            self.empty_state.set_title(_("No Mods Installed Yet"))
+            self.empty_state.set_description(
+                _("You haven't installed any mods for this game yet.\n"
+                  "Browse Nexus Mods to download mods with 'Mod Manager Download', or install downloaded archives from the Downloads tab.")
+            )
+            self.empty_migrate_btn.remove_css_class("suggested-action")
+
+    def on_scan_and_migrate_legacy_mods(self, btn=None):
+        def do_scan():
+            legacy_mods = scan_legacy_mods(self.dashboard.game_info, self.dashboard.staging_path)
+            GLib.idle_add(show_migration_dialog, legacy_mods)
+
+        def show_migration_dialog(legacy_mods):
+            if not legacy_mods:
+                self.dashboard.show_message(
+                    _("No Legacy Mods Found"),
+                    _("No unmanaged mod files were detected in the game directory.")
+                )
+                return
+
+            mod_names_preview = "\n".join(
+                f"• {m['name']} ({len(m['files'])} file{'s' if len(m['files']) > 1 else ''})"
+                for m in legacy_mods[:10]
+            )
+            if len(legacy_mods) > 10:
+                mod_names_preview += f"\n... and {len(legacy_mods) - 10} more"
+
+            dialog = Adw.MessageDialog(
+                transient_for=self.dashboard.app.win,
+                heading=_("Migrate Legacy Mods"),
+                body=_("Found {} unmanaged mod(s) in the game directory:\n\n{}\n\n"
+                       "Would you like NOMM to import and manage them?\n\n"
+                       "Files will be moved to NOMM's staging directory and symlinked back into the game directory so your game continues to work seamlessly.").format(
+                    len(legacy_mods), mod_names_preview
+                )
+            )
+            dialog.add_response("cancel", _("Cancel"))
+            dialog.add_response("migrate", _("Migrate ({} mods)").format(len(legacy_mods)))
+            dialog.set_response_appearance("migrate", Adw.ResponseAppearance.SUGGESTED)
+            dialog.set_default_response("migrate")
+
+            def on_response(d, response_id):
+                if response_id == "migrate":
+                    d.close()
+                    self.execute_migration(legacy_mods)
+
+            dialog.connect("response", on_response)
+            dialog.present()
+
+        threading.Thread(target=do_scan, daemon=True).start()
+
+    def execute_migration(self, legacy_mods):
+        def do_migrate():
+            count, errors = migrate_legacy_mods(
+                self.dashboard.game_info,
+                self.dashboard.staging_path,
+                self.dashboard.staging_metadata_path,
+                legacy_mods
+            )
+            GLib.idle_add(on_migration_complete, count, errors)
+
+        def on_migration_complete(count, errors):
+            self.populate_list()
+            self.dashboard.update_indicators()
+            if count > 0:
+                self.dashboard.show_message(
+                    _("Migration Complete"),
+                    _("Successfully migrated {} mod(s) into NOMM!").format(count)
+                )
+            elif errors:
+                self.dashboard.show_message(
+                    _("Migration Failed"),
+                    _("Could not migrate mods:\n{}").format("\n".join(errors[:5]))
+                )
+
+        threading.Thread(target=do_migrate, daemon=True).start()
+

--- a/src/gui/dashboard_views/mods_tab.py
+++ b/src/gui/dashboard_views/mods_tab.py
@@ -57,6 +57,26 @@ class ModsTab(Gtk.Box):
         
         action_bar.append(filter_group)
 
+        spacer = Gtk.Box(hexpand=True)
+        action_bar.append(spacer)
+
+        if "nexus_id" in dashboard.game_config:
+            nexus_id = dashboard.game_config["nexus_id"]
+            nexus_btn = create_icon_button(
+                icon_name="nexus-logo",
+                tooltip=_("Open Nexus Mods page"),
+                on_click=lambda x: webbrowser.open(f"https://www.nexusmods.com/{nexus_id}/mods/")
+            )
+            action_bar.append(nexus_btn)
+
+        if "wiki_link" in dashboard.game_config:
+            wiki_btn = create_icon_button(
+                icon_name="globe-book-symbolic",
+                tooltip=_("Open wiki page"),
+                on_click=lambda x: webbrowser.open(f"https://nomm.moe/docs/game-guides/{dashboard.game_config['wiki_link']}")
+            )
+            action_bar.append(wiki_btn)
+
         folder_btn = create_icon_button(
             icon_name="mat-folder-symbolic",
             tooltip=_("Open staging folder"),
@@ -67,20 +87,7 @@ class ModsTab(Gtk.Box):
             tooltip=_("Refresh Metadata & Check for updates\nThis will replace all current mod metadata with fresh data coming straight from the modding platform."),
             on_click=self.check_for_updates
         )
-        
-        if "wiki_link" in dashboard.game_config:
-            wiki_btn = create_icon_button(
-                icon_name="globe-book-symbolic",
-                tooltip=_("Open wiki page"),
-                on_click=lambda x: webbrowser.open(f"https://nomm.moe/docs/game-guides/{dashboard.game_config["wiki_link"]}")
-            )
-            wiki_btn.set_hexpand(True)
-            action_bar.append(wiki_btn)
-        else:
-            # This is so that the buttons all show up on the right side, even if there is no wiki button
-            folder_btn.set_hexpand(True)
 
-        # Add all the buttons
         action_bar.append(folder_btn)
         action_bar.append(update_btn)
 
@@ -112,6 +119,46 @@ class ModsTab(Gtk.Box):
         self.revealer.set_hexpand(False) 
         self.revealer.set_halign(Gtk.Align.END)
         self.main_content.append(self.revealer)
+
+        # Empty State
+        self.empty_state = Adw.StatusPage(
+            icon_name="nexus-logo" if "nexus_id" in dashboard.game_config else "nomm-logo",
+            title=_("No Mods Installed Yet"),
+            description=_("You haven't installed any mods for this game yet.\nBrowse Nexus Mods to download mods with 'Mod Manager Download', or install downloaded archives from the Downloads tab."),
+            vexpand=True,
+            hexpand=True
+        )
+        
+        empty_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, halign=Gtk.Align.CENTER)
+        
+        if "nexus_id" in dashboard.game_config:
+            nexus_id = dashboard.game_config["nexus_id"]
+            browse_nexus_btn = Gtk.Button()
+            browse_nexus_btn.set_child(Adw.ButtonContent(icon_name="nexus-logo", label=_("Browse Nexus Mods")))
+            browse_nexus_btn.add_css_class("suggested-action")
+            browse_nexus_btn.add_css_class("pill")
+            browse_nexus_btn.set_cursor_from_name("pointer")
+            browse_nexus_btn.connect("clicked", lambda x: webbrowser.open(f"https://www.nexusmods.com/{nexus_id}/mods/"))
+            empty_buttons.append(browse_nexus_btn)
+
+        downloads_btn = Gtk.Button()
+        downloads_btn.set_child(Adw.ButtonContent(icon_name="folder-download-symbolic", label=_("Go to Downloads")))
+        downloads_btn.add_css_class("pill")
+        downloads_btn.set_cursor_from_name("pointer")
+        downloads_btn.connect("clicked", lambda x: self.dashboard.dl_tab_btn.set_active(True))
+        empty_buttons.append(downloads_btn)
+
+        if "wiki_link" in dashboard.game_config:
+            wiki_guide_btn = Gtk.Button()
+            wiki_guide_btn.set_child(Adw.ButtonContent(icon_name="globe-book-symbolic", label=_("Modding Guide")))
+            wiki_guide_btn.add_css_class("pill")
+            wiki_guide_btn.set_cursor_from_name("pointer")
+            wiki_guide_btn.connect("clicked", lambda x: webbrowser.open(f"https://nomm.moe/docs/game-guides/{dashboard.game_config['wiki_link']}"))
+            empty_buttons.append(wiki_guide_btn)
+
+        self.empty_state.set_child(empty_buttons)
+        self.append(self.empty_state)
+        self.empty_state.set_visible(False)
 
         self.setup_preview_pane()
         self.populate_list()
@@ -741,8 +788,12 @@ class ModsTab(Gtk.Box):
                 self.mods_list_box.remove(child)
 
             if not staging_metadata or not staging_metadata.get("mods"):
-                self.append(Gtk.Label(label=_("The staging metadata file could not be found, did you install any mods?"), css_classes=["dim-label"]))
+                self.main_content.set_visible(False)
+                self.empty_state.set_visible(True)
                 return
+            else:
+                self.empty_state.set_visible(False)
+                self.main_content.set_visible(True)
 
             file_badge_sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
             load_index_sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)

--- a/src/platforms/switch.py
+++ b/src/platforms/switch.py
@@ -23,26 +23,28 @@ class EmulatorName(Enum):
     CITRON = "Citron"
     
 def find_matches(game_configs_dir) -> list:
-
     switch_config_path = os.path.join(game_configs_dir, "emulation/switch.yaml")
-    if not os.path.exists(switch_config_path) or list_emulators() == [] :
+    emulators = list_emulators()
+    if not os.path.exists(switch_config_path) or not emulators:
         return []
 
     PLATFORM = "switch"
     
-    emulator_name_str = load_user_config().get("preferred_switch_emulator", list_emulators()[0])
+    preferred = load_user_config().get("preferred_switch_emulator")
+    emulator_name_str = preferred if preferred in emulators else emulators[0]
     
     try:
         preferred_emulator = EmulatorName(emulator_name_str)
     except ValueError as e:
-        print(f"Preferred emulator value is not supported")
-        return[]
+        print(f"Preferred emulator value is not supported: {e}")
+        return []
     
     try:
-        with open(switch_config_path, 'r') as f:
-            supported_switch_games = yaml.safe_load(f)
+        with open(switch_config_path, 'r', encoding='utf-8') as f:
+            supported_switch_games = yaml.safe_load(f) or []
     except Exception as e:
         print(f"Was not able to load switch config - is it improperly formatted? {e}")
+        return []
 
     if preferred_emulator == EmulatorName.CITRON:
         game_path = CITRON_GAME_PATH
@@ -53,8 +55,18 @@ def find_matches(game_configs_dir) -> list:
     elif preferred_emulator == EmulatorName.RYUBING:
         game_path = RYUBING_GAME_PATH
         mods_path = RYUBING_MOD_PATH
+    else:
+        return []
     
-    installed_games = os.listdir(game_path)
+    if not os.path.isdir(game_path):
+        return []
+
+    try:
+        installed_games = os.listdir(game_path)
+    except OSError as e:
+        print(f"Failed to list switch games in {game_path}: {e}")
+        return []
+
     matches = []
 
     for game in supported_switch_games:
@@ -66,7 +78,7 @@ def find_matches(game_configs_dir) -> list:
         if game_id in installed_games:
             art = load_cached_assets(game["full_name"], PLATFORM)
             if not art:
-                cache_base = os.path.join(GLib.get_user_data_dir(), "nomm", "image-cache", PLATFORM, f"{game["full_name"]}")
+                cache_base = os.path.join(GLib.get_user_data_dir(), "nomm", "image-cache", PLATFORM, f"{game['full_name']}")
                 grid_path = os.path.join(cache_base, "art_grid.jpg")
                 download_image(game["grid_url"], grid_path)
                 hero_path = os.path.join(cache_base, "art_hero.jpg")
@@ -96,11 +108,11 @@ def find_matches(game_configs_dir) -> list:
 def list_emulators():
     """Lists Switch emulators installed on user's system"""
     installed_emulator_list = []
-    if os.path.exists(CITRON_GAME_PATH):
+    if os.path.isdir(CITRON_GAME_PATH):
         installed_emulator_list.append(EmulatorName.CITRON.value)
-    if os.path.exists(EDEN_GAME_PATH):
+    if os.path.isdir(EDEN_GAME_PATH):
         installed_emulator_list.append(EmulatorName.EDEN.value)
-    if os.path.exists(RYUBING_GAME_PATH):
+    if os.path.isdir(RYUBING_GAME_PATH):
         installed_emulator_list.append(EmulatorName.RYUBING.value)
 
     return installed_emulator_list
@@ -109,7 +121,8 @@ def get_emulator_logo(emulator):
     try:
         emulator = EmulatorName(emulator)
     except ValueError as e:
-        print(f"Preferred emulator value is not supported")
+        print(f"Preferred emulator value is not supported: {e}")
+        return None
     
     if emulator == EmulatorName.CITRON:
         return "citron-logo"
@@ -117,3 +130,4 @@ def get_emulator_logo(emulator):
         return "eden-logo"
     elif emulator == EmulatorName.RYUBING:
         return "ryubing-logo"
+    return None

--- a/src/styles/_buttons.css
+++ b/src/styles/_buttons.css
@@ -41,7 +41,7 @@
 }
 
 .btn-download-before {
-    background-color: shade(--card_bg_color, 0.6);
+    background-color: shade(@card_bg_color, 0.6);
 }
 
 /* Icons in the main dashboard list such as the update available icon or warning icons */


### PR DESCRIPTION
While testing Switch games in NOMM, I noticed there was no clear way to find or manage Switch mods from the UI. GameBanana is the main modding platform for Switch titles, but the dashboard only showed Nexus links and generic empty panels. Also, opening a Switch game caused a crash because of an unhandled attribute ordering issue in the dashboard initialization.

Here is what I changed:

1. First, I fixed the crash when clicking on a Switch game in the library view by making sure app_id is assigned before evaluating game_config and handling the list-based structure of switch.yaml properly.

2. Next, I added GameBanana integration to the UI. For any Switch game, the action bar now includes a GameBanana button that opens the game's search page directly (using the Game model filter and best match ordering).

3. I also updated both the Mods and Downloads tabs with Switch-specific status pages. They explain that Switch mods typically come from GameBanana as archives with romfs or exefs folders, and give you a one-click button to browse GameBanana or drop your mod archives into the window.

4. Finally, I updated list_archives in tools.py to recognize .bnp files (the mod format commonly used for Zelda BotW and TotK) as well as tar, gz, and xz archives, so they can be dragged and dropped into NOMM and installed without needing manual renaming.

