### PR TITLE
No steam launch

### DIFF
--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -427,6 +427,8 @@ class Nomm(Adw.Application):
         self.stack.set_visible_child_name("preferred_emu")
 
     def steam_user_id_handler(self):
+        if not self.steam_base:
+            self.finalize_setup()
         steam_userdata_path = self.steam_base + "userdata/"
         steam_user_ids = [f for f in os.listdir(steam_userdata_path) if os.path.isdir(os.path.join(steam_userdata_path, f))]
         if "0" in steam_user_ids:

--- a/src/platforms/steam.py
+++ b/src/platforms/steam.py
@@ -25,6 +25,9 @@ def get_steam_base_dir() -> Optional[str]:
 def get_library_paths(steam_base) -> List[str]:
     libraries = []
 
+    if not steam_base:
+        return libraries
+
     vdf_path = os.path.join(steam_base, "config/libraryfolders.vdf")
 
     try:


### PR DESCRIPTION
NOMM no longer needs a steam installation to be present
- During first time setup
- During library scanning