### PR TITLE
Flatpak portal permissions enhancement

### DIFF
--- a/build/aur-nightly/PKGBUILD
+++ b/build/aur-nightly/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=nomm-git
 pkgrel=1
-_pkgbase=0.12.5
+_pkgbase=0.12.6
 pkgver=0.12.2.c844
 pkgdesc="Native Open Mod Manager - a mod manager for Linux"
 arch=('any')

--- a/build/aur/PKGBUILD
+++ b/build/aur/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=nomm
-pkgver=0.12.5
+pkgver=0.12.6
 pkgrel=1
 pkgdesc="Native Open Mod Manager - a mod manager for Linux"
 arch=('any')

--- a/build/flatpak/moe.nomm.Nomm.metainfo.xml
+++ b/build/flatpak/moe.nomm.Nomm.metainfo.xml
@@ -39,6 +39,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.12.6" date="2026-08-26">
+      <url type="details">https://github.com/Allexio/nomm/releases/tag/0.12.6</url>
+      <description>
+        <p>Release bites</p>
+          <ul>
+            <li>Use portal path instead of real path for staging and downloads</li>
+          </ul>
+      </description>
+    </release>
     <release version="0.12.5" date="2026-08-24">
       <url type="details">https://github.com/Allexio/nomm/releases/tag/0.12.5</url>
       <description>

--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -46,11 +46,12 @@ def timestamp_converter(timestamp: str, timestamp_type="short") -> str:
         return timestamp.strftime("%x %H:%M")
     return legible_timestamp
 
-def translate_fuse_path(folder_info) -> str:
+def translate_fuse_path(folder_info) -> tuple[str, str]:
     folder_path = folder_info.get_path()
+    translated_path = ""
     if "run/user" in folder_path:
         print(f"Detected sandboxed path: {folder_path}")
-        try:
+        try: 
             # Get FileInfo for File
             file_info = folder_info.query_info("xattr::document-portal.host-path", Gio.FileQueryInfoFlags.NONE, None)
 
@@ -58,10 +59,10 @@ def translate_fuse_path(folder_info) -> str:
             real_path = file_info.get_attribute_string("xattr::document-portal.host-path")
             if real_path is not None: # Attribute does not exist if None
                 print(f"Real path parsed: {real_path}")
-                return real_path
+                translated_path = real_path
         except GLib.Error:
             print("Can not get real path. If you see this message you will need to manually give NOMM host filesystem permissions.")
-    return folder_path
+    return folder_path, translated_path
 
 
 

--- a/src/gui/app_views/settings.py
+++ b/src/gui/app_views/settings.py
@@ -253,7 +253,10 @@ class SettingsWindow(Adw.Window):
                     folder_path , translated_folder_path = translate_fuse_path(folder)
                     update_user_config(config_key, folder_path)
                     update_user_config("translated_"+config_key, translated_folder_path)
-                    row.set_subtitle(folder_path)
+                    if translated_folder_path:
+                        row.set_subtitle(translated_folder_path)
+                    else:
+                        row.set_subtitle(folder_path)
             except Exception as e:
                 print(f"Folder selection failed: {e}")
 

--- a/src/gui/app_views/settings.py
+++ b/src/gui/app_views/settings.py
@@ -99,8 +99,10 @@ class SettingsWindow(Adw.Window):
 
         # Downloads Path Row
         self.path_row = Adw.ActionRow(title=_("Mod Downloads Path"))
-        current_path = user_config.get('download_path', 'Not set')
-        self.path_row.set_subtitle(current_path)
+        current_download_path = user_config.get('download_path', 'Not set')
+        if "/run/user" in current_download_path:
+            current_download_path = user_config.get('translated_download_path', 'Not set')
+        self.path_row.set_subtitle(current_download_path)
 
         folder_btn = create_icon_button(
             icon_name="mat-folder-managed-symbolic",
@@ -112,8 +114,10 @@ class SettingsWindow(Adw.Window):
 
         # Staging Path Row
         self.staging_row = Adw.ActionRow(title=_("Mod Staging Path"))
-        current_staging = user_config.get('staging_path', 'Not set')
-        self.staging_row.set_subtitle(current_staging)
+        current_staging_path = user_config.get('staging_path', 'Not set')
+        if "/run/user" in current_staging_path:
+            current_staging_path = user_config.get('translated_staging_path', 'Not set')
+        self.staging_row.set_subtitle(current_staging_path)
 
         staging_btn = create_icon_button(
             icon_name="mat-folder-managed-symbolic",
@@ -246,8 +250,9 @@ class SettingsWindow(Adw.Window):
                 folder = dialog.select_folder_finish(result)
                 if folder:
                     print("new folder selected")
-                    folder_path = translate_fuse_path(folder)
+                    folder_path , translated_folder_path = translate_fuse_path(folder)
                     update_user_config(config_key, folder_path)
+                    update_user_config("translated_"+config_key, translated_folder_path)
                     row.set_subtitle(folder_path)
             except Exception as e:
                 print(f"Folder selection failed: {e}")

--- a/src/gui/app_views/settings.py
+++ b/src/gui/app_views/settings.py
@@ -23,6 +23,8 @@ class SettingsWindow(Adw.Window):
         self.user_config_dir = os.path.join(GLib.get_user_data_dir(), "nomm",)
         self.user_config_path = os.path.join(self.user_config_dir, "user_config.yaml")
 
+        user_config = load_yaml(self.user_config_path)
+
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20, margin_top=24, margin_bottom=24, margin_start=24, margin_end=24)
         self.set_content(content)
 
@@ -94,9 +96,10 @@ class SettingsWindow(Adw.Window):
         storage_group = Adw.PreferencesGroup(title=_("NOMM Paths"))
         settings_scrollbox.append(storage_group)
 
+
         # Downloads Path Row
         self.path_row = Adw.ActionRow(title=_("Mod Downloads Path"))
-        current_path = load_yaml(self.user_config_path).get('download_path', 'Not set')
+        current_path = user_config.get('download_path', 'Not set')
         self.path_row.set_subtitle(current_path)
 
         folder_btn = create_icon_button(
@@ -109,7 +112,7 @@ class SettingsWindow(Adw.Window):
 
         # Staging Path Row
         self.staging_row = Adw.ActionRow(title=_("Mod Staging Path"))
-        current_staging = load_yaml(self.user_config_path).get('staging_path', 'Not set')
+        current_staging = user_config.get('staging_path', 'Not set')
         self.staging_row.set_subtitle(current_staging)
 
         staging_btn = create_icon_button(
@@ -138,7 +141,7 @@ class SettingsWindow(Adw.Window):
 
         self.api_entry = Gtk.PasswordEntry(hexpand=True, valign=Gtk.Align.CENTER)
         self.api_entry.set_property("placeholder-text", _("Paste API Key..."))
-        self.api_entry.set_text(load_yaml(self.user_config_path).get('nexus_api_key', ''))
+        self.api_entry.set_text(user_config.get('nexus_api_key', ''))
 
         self.check_btn = Gtk.Button(icon_name="mat-experiment-symbolic", valign=Gtk.Align.CENTER, css_classes=["flat", "large-icon-btn"])
         self.check_btn.set_tooltip_text(_("Check API key validity"))
@@ -161,7 +164,7 @@ class SettingsWindow(Adw.Window):
         installed_emulators = list_emulators()
         if installed_emulators:
             options_model = Gtk.StringList.new(installed_emulators)
-            current_emulator = load_yaml(self.user_config_path).get('preferred_switch_emulator')
+            current_emulator = user_config.get('preferred_switch_emulator')
             selected_index = installed_emulators.index(current_emulator) if current_emulator in installed_emulators else 0
 
             switch_emulator_row = Adw.ComboRow(
@@ -176,7 +179,7 @@ class SettingsWindow(Adw.Window):
         # Library sort
         sorting_options = [sort.display_name for sort in LibrarySort]
         options_model = Gtk.StringList.new(sorting_options)
-        current_sort_str = load_yaml(self.user_config_path).get("library_sort", "Number of Mods")
+        current_sort_str = user_config.get("library_sort", "Number of Mods")
         current_sort = LibrarySort.from_string(current_sort_str)
         selected_index = list(LibrarySort).index(current_sort)
 
@@ -192,29 +195,28 @@ class SettingsWindow(Adw.Window):
         # Per-game accent colours
         accent_row = Adw.SwitchRow(title=_("Per-Game Accent Colour"))
         accent_row.set_subtitle(_("Accent colour will change for each game depending on configuration"))
-        accent_row.set_active(load_yaml(self.user_config_path).get('enable_per_game_accent_colour', False))
+        accent_row.set_active(user_config.get('enable_per_game_accent_colour', False))
         accent_row.connect("notify::active", lambda row, pspec: self.toggle_setting('enable_per_game_accent_colour', row.get_active()))
         general_group.add(accent_row)
-
 
         # Skip launcher
         launcher_skip_row = Adw.SwitchRow(title=_("Skip Launcher"))
         launcher_skip_row.set_subtitle(_("App launches last used game profile instead of starting up launcher"))
-        launcher_skip_row.set_active(load_yaml(self.user_config_path).get('enable_launcher_skip', False))
+        launcher_skip_row.set_active(user_config.get('enable_launcher_skip', False))
         launcher_skip_row.connect("notify::active", lambda row, pspec: self.toggle_setting('enable_launcher_skip', row.get_active()))
         general_group.add(launcher_skip_row)
-        
+
         # Skip launcher
         download_popup = Adw.SwitchRow(title=_("Disable Download Window"))
         download_popup.set_subtitle(_("Disables mod downloads spawning a separate window"))
-        download_popup.set_active(load_yaml(self.user_config_path).get('disable_download_window', False))
+        download_popup.set_active(user_config.get('disable_download_window', False))
         download_popup.connect("notify::active", lambda row, pspec: self.toggle_setting('disable_download_window', row.get_active()))
         general_group.add(download_popup)
 
         # Fullscreen
         fullscreen_row = Adw.SwitchRow(title=_("Fullscreen NOMM"))
         fullscreen_row.set_subtitle(_("App launches in full screen when you select a game"))
-        fullscreen_row.set_active(load_yaml(self.user_config_path).get('enable_fullscreen', False))
+        fullscreen_row.set_active(user_config.get('enable_fullscreen', False))
         fullscreen_row.connect("notify::active", lambda row, pspec: self.toggle_setting('enable_fullscreen', row.get_active()))
         general_group.add(fullscreen_row)
 

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -51,7 +51,6 @@ class Nomm(Adw.Application):
         
         super().__init__(application_id=APP_NAME, flags=Gio.ApplicationFlags.HANDLES_OPEN, **kwargs)
         self.matches: list[dict] = []
-        self.user_defined_paths = []
         self.steam_base = get_steam_base_dir()
 
         user_data_dir: str = os.path.join(GLib.get_user_data_dir(), 'nomm')
@@ -283,7 +282,6 @@ class Nomm(Adw.Application):
     def on_downloads_folder_selected_callback(self, dialog, result):
         selected_folder_path, translated_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
         self.temp_config = {"download_path": selected_folder_path, "translated_download_path": translated_folder_path, "library_paths": []}
-        self.user_defined_paths = [selected_folder_path]
         self.show_staging_select_screen()
 
     def show_staging_select_screen(self):
@@ -314,7 +312,6 @@ class Nomm(Adw.Application):
         selected_folder_path, translated_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
         self.temp_config["staging_path"] = selected_folder_path
         self.temp_config["translated_staging_path"] = translated_folder_path
-        self.user_defined_paths.append(selected_folder_path)
         self.show_nexus_api_key_screen()
 
     def show_nexus_api_key_screen(self):

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -28,7 +28,7 @@ from platforms.gamebanana import handle_gamebanana_link
 from platforms.steam import get_username_from_steam_id, get_steam_base_dir
 
 APP_NAME = 'moe.nomm.Nomm'
-APP_VERSION = '0.12.5'
+APP_VERSION = '0.12.6'
 LOCALE_DIR = '/app/share/locale'
 
 # Localisation setup

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -281,8 +281,8 @@ class Nomm(Adw.Application):
         dialog.select_folder(self.win, None, self.on_downloads_folder_selected_callback)
 
     def on_downloads_folder_selected_callback(self, dialog, result):
-        selected_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
-        self.temp_config = {"download_path": selected_folder_path, "library_paths": []}
+        selected_folder_path, translated_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
+        self.temp_config = {"download_path": selected_folder_path, "translated_download_path": translated_folder_path, "library_paths": []}
         self.user_defined_paths = [selected_folder_path]
         self.show_staging_select_screen()
 
@@ -311,8 +311,9 @@ class Nomm(Adw.Application):
         dialog.select_folder(self.win, None, self.on_staging_folder_selected_callback)
 
     def on_staging_folder_selected_callback(self, dialog, result):
-        selected_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
+        selected_folder_path, translated_folder_path = translate_fuse_path(dialog.select_folder_finish(result))
         self.temp_config["staging_path"] = selected_folder_path
+        self.temp_config["translated_staging_path"] = translated_folder_path
         self.user_defined_paths.append(selected_folder_path)
         self.show_nexus_api_key_screen()
 


### PR DESCRIPTION
Review downloads & staging paths logic.

Before:
1. User selects directory with the file picker during first time setup
2. Directory path is translated from fuse (/run/user/1000/etc.) to "standard" (/home/user/downloads/nomm/). Fuse path is discarded.
3. Request is made to user to provide access to standard paths

After:
1. User selects directory with the file picker during first time setup
2. Directory path is translated from fuse (/run/user/100/etc.) to "standard" (/home/user/downloads/nomm/) **but the original fuse path is kept and used instead of the standard path**

Consequences: 
- When a path needs to be displayed in the UI (i.e. in the settings screen), the translated (standard) path is used.
- The user no longer needs to provide override access to the download and staging paths (but still needs to provide override access to libraries)


The settings file picker to change staging/download folder locations has been updated as well to use the same logic.

(Additionally I added two small refacs I noticed during the development, including one that replaced 10 yaml file reads by a single one :facepalm:)