### PR TITLE
Semi automated releases

### DIFF
--- a/.github/workflows/update-metainfo.yaml
+++ b/.github/workflows/update-metainfo.yaml
@@ -38,3 +38,23 @@ jobs:
         with:
           commit_message: "Chore: update metainfo.xml release notes"
           file_pattern: "build/flatpak/moe.nomm.Nomm.metainfo.xml"
+      
+      - name: Update PKGBUILD and .SRCINFO for stable release
+        run: |
+          cd build/aur
+          makepkg -sif
+          makepkg --printsrcinfo > .SRCINFO
+          updpkgsums
+          
+      - name: Update PKGBUILD and .SRCINFO for git release
+        run: |
+          cd build/aur-nightly
+          makepkg -sif
+          makepkg --printsrcinfo > .SRCINFO
+          updpkgsums
+        
+      - name: Commit and Push changes for PKGBUILD
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Chore: bumped PKGBUILD version"
+          file_pattern: "build/aur/PKGBUILD build/aur/.SRCINFO build/aur-nightly/PKGBUILD build/aur-nightly/.SRCINFO"

--- a/.github/workflows/update-metainfo.yaml
+++ b/.github/workflows/update-metainfo.yaml
@@ -1,11 +1,11 @@
-name: Update AppStream Metainfo News (Arch)
+name: Auto-export AppStream Metainfo Release Notes
 
 on:
   push:
     branches:
       - '**'
     paths:
-      - 'release-bites.yaml'
+      - 'release_bites.yaml'
 
 jobs:
   update-metainfo:
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update Metainfo XML
         run: |
-          appstreamcli news-to-metainfo --limit=6 ./release-bites.yaml ./build/flatpak/moe.nomm.Nomm.metainfo.xml
+          appstreamcli news-to-metainfo --limit=6 ./release_bites.yaml ./build/flatpak/moe.nomm.Nomm.metainfo.xml
 
       - name: Commit and Push changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/update-metainfo.yaml
+++ b/.github/workflows/update-metainfo.yaml
@@ -1,0 +1,40 @@
+name: Update AppStream Metainfo News (Arch)
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'release-bites.yaml'
+
+jobs:
+  update-metainfo:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest # I use arch to make sure I get latest appstream
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install latest appstream
+        run: |
+          pacman -Sy --noconfirm git appstream
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure target directory exists
+        run: mkdir -p build/flatpak
+
+      - name: Update Metainfo XML
+        run: |
+          appstreamcli news-to-metainfo --limit=6 ./release-bites.yaml ./build/flatpak/moe.nomm.Nomm.metainfo.xml
+
+      - name: Commit and Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Chore: update metainfo.xml release notes"
+          file_pattern: "build/flatpak/moe.nomm.Nomm.metainfo.xml"

--- a/build/aur-nightly/PKGBUILD
+++ b/build/aur-nightly/PKGBUILD
@@ -27,7 +27,8 @@ sha256sums=('SKIP')
 
 pkgver() {
     cd "nomm"
-    printf "%s.c%s" "$_pkgbase" "$(git rev-list --count HEAD)"
+    ver=yq -r '.Version' $startdir/../../release_bites.yaml | head -n 1
+    printf "%s.c%s" "$ver" "$(git rev-list --count HEAD)"
 }
 
 package() {

--- a/build/aur/.SRCINFO
+++ b/build/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nomm
 	pkgdesc = Native Open Mod Manager - a mod manager for Linux
-	pkgver = 0.8.0
+	pkgver = 0.12.2
 	pkgrel = 1
 	url = https://github.com/Allexio/nomm
 	arch = any
@@ -16,7 +16,7 @@ pkgbase = nomm
 	depends = unrar
 	depends = python-vdf
 	depends = python-rarfile
-	source = nomm-0.8.0.tar.gz::https://github.com/Allexio/nomm/archive/refs/tags/0.8.0.tar.gz
-	sha256sums = 54b90cd921e9b7aee800d0cd3e149b523a48517a8fcbb084f180daabfec42e50
+	source = nomm-0.12.2.tar.gz::https://github.com/Allexio/nomm/archive/refs/tags/0.12.2.tar.gz
+	sha256sums = SKIP
 
 pkgname = nomm

--- a/build/aur/PKGBUILD
+++ b/build/aur/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=nomm
-pkgver=0.12.6
+pkgver=0.12.2
 pkgrel=1
 pkgdesc="Native Open Mod Manager - a mod manager for Linux"
 arch=('any')
@@ -21,7 +21,11 @@ makedepends=(
     'gettext'
 )
 source=("$pkgname-$pkgver.tar.gz::https://github.com/Allexio/nomm/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('a182a29e68806eeec8c08024b39ae6c6ca80226b349cf280561214918e78d294')
+
+pkgver() {
+    yq -r '.Version' $startdir/../../release_bites.yaml | head -n 1
+}
 
 package() {
     cd "nomm-$pkgver"

--- a/build/flatpak/moe.nomm.Nomm.yaml
+++ b/build/flatpak/moe.nomm.Nomm.yaml
@@ -66,6 +66,8 @@ modules:
       - cp -r src/platforms /app/bin/platforms
       # Other files (shenanigans)
       - cp src/*.yaml /app/bin/
+      # Release_bites -> used for in-app version numbering
+      - cp release_bites.yaml /app/bin/
       # Copy non-code folders
       - cp -r assets /app/bin/assets
       - cp -r default_game_configs /app/bin/default_game_configs

--- a/release_bites.yaml
+++ b/release_bites.yaml
@@ -1,0 +1,33 @@
+---
+Version: "0.12.6"
+Date: 2026-08-26
+Description: |-
+  Release bites
+   * Use portal path instead of real path for staging and downloads
+---
+Version: "0.12.5"
+Date: 2026-08-24
+Description: |-
+  Release bites
+   * Fixed regression stopping utilities from being correctly downloaded
+---
+Version: "0.12.4"
+Date: 2026-08-24
+Description: |-
+  Release bites
+   * NOMM can now be properly launched even when no Steam installation is present on user system
+   * Fixed some minor UI issues in first time setup screens (bundled icons, staging select button
+     width, crossfade)
+---
+Version: "0.12.3"
+Date: 2026-08-23
+Description: |-
+  Release bites
+   * Additional changes for Flathub support
+---
+Version: "0.12.2"
+Date: 2026-08-19
+Description: |-
+  Release bites
+   * Name change from com.nomm.Nomm to moe.nomm.Nomm
+   * Minor bugfix during first launch with GOG games installed

--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -296,3 +296,13 @@ def create_icon_button(
         button.connect("clicked", on_click)
 
     return button
+
+def load_nomm_version() -> str:
+    release_bites_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "release_bites.yaml")
+    if not os.path.exists(release_bites_path):
+        release_bites_path = os.path.join(os.path.dirname(os.path.dirname(release_bites_path)), "release_bites.yaml")
+    
+    with open(release_bites_path, 'r') as f:
+        release_bites = list(yaml.safe_load_all(f))
+
+    return release_bites[0]["Version"]

--- a/src/gui/application.py
+++ b/src/gui/application.py
@@ -16,7 +16,7 @@ from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
 from core.game_scanner import scan_all_games
 from core.tools import (load_yaml,
-                        translate_fuse_path, write_yaml)
+                        translate_fuse_path, write_yaml, load_nomm_version)
 from core.user_config import (load_user_config, update_user_config,
                               write_user_config)
 from platforms.switch import list_emulators, get_emulator_logo
@@ -28,7 +28,7 @@ from platforms.gamebanana import handle_gamebanana_link
 from platforms.steam import get_username_from_steam_id, get_steam_base_dir
 
 APP_NAME = 'moe.nomm.Nomm'
-APP_VERSION = '0.12.6'
+APP_VERSION = load_nomm_version()
 LOCALE_DIR = '/app/share/locale'
 
 # Localisation setup


### PR DESCRIPTION
New file added:
`release_bites.yaml`

This file will be the new single place where we keep
- NOMM versions
- NOMM release notes

Automatically after every commit that changes `release_bites.yaml`, a github action will be run that exports this information to the metainfo.xml appstream file in the same branch.

NOMM's main code now reads the latest version from `release_bites.yaml` instead of having the version hard coded in `application.py`.